### PR TITLE
Add basic translation search page

### DIFF
--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useLanguage } from '../../context/LanguageContext';
+
+const PREFIX_TO_ROUTE: Record<string, string> = {
+  home: '/',
+  wifi_plus: '/wifi-plus',
+  optionsandservices: '/mobile-options',
+  promorazuieste: '/weekend-cu-beneficii',
+  magazine: '/magazine',
+  mobile: '/mobile',
+  triple: '/triple',
+  one_number: '/one-number',
+};
+
+function collectKeys(
+  obj: Record<string, any>,
+  query: string,
+  path: string[] = []
+): string[] {
+  let matches: string[] = [];
+  for (const [key, value] of Object.entries(obj)) {
+    const newPath = [...path, key];
+    if (typeof value === 'string') {
+      if (value.toLowerCase().includes(query.toLowerCase())) {
+        matches.push(newPath.join('.'));
+      }
+    } else if (typeof value === 'object') {
+      matches = matches.concat(collectKeys(value as Record<string, any>, query, newPath));
+    }
+  }
+  return matches;
+}
+
+export default function SearchPage() {
+  const { language } = useLanguage();
+  const { i18n } = useTranslation();
+  const [query, setQuery] = useState('');
+  const [pages, setPages] = useState<string[]>([]);
+
+  const onSearch = () => {
+    const bundle = i18n.getResourceBundle(language, 'translation') as Record<string, any>;
+    const keys = collectKeys(bundle, query);
+    const found = new Set<string>();
+    keys.forEach(k => {
+      const prefix = k.split('.')[0];
+      const route = PREFIX_TO_ROUTE[prefix] || '*';
+      found.add(route);
+    });
+    setPages(Array.from(found));
+  };
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <input
+        type="text"
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        placeholder="Search..."
+      />
+      <button onClick={onSearch}>Search</button>
+      <ul>
+        {pages.map(page => (
+          <li key={page}>
+            {page === '*' ? (
+              <span>General content</span>
+            ) : (
+              <Link to={`/${language}${page}`}>{page}</Link>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/routesConfig.tsx
+++ b/src/routesConfig.tsx
@@ -8,6 +8,7 @@ import IconShowcase from './pages/technical/IconShowcase.tsx';
 import WifiPlus from './pages/personal/oferte/wifiplus/WifiPlus.tsx';
 import OptionsandServices from './pages/personal/oferte/optionsandservices/OptionsandServices.tsx';
 import PromoRazuieste from './pages/personal/oferte/promo_razuieste/PromoRazuieste.tsx';
+import SearchPage from './pages/search/Search.tsx';
 
 import Home from './pages/home/Home_v2.tsx';
 import OneNumber from './pages/personal/oferte/one_number/OneNumber.tsx';
@@ -77,6 +78,11 @@ export const routesConfig: RouteConfig[] = [
     path: '/:lang/one-number',
     i18nKey: 'not_found.title',
     element: React.createElement(OneNumber),
+  },
+  {
+    path: '/:lang/search',
+    i18nKey: 'not_found.title',
+    element: React.createElement(SearchPage),
   },
   {
     path: '*',


### PR DESCRIPTION
## Summary
- add SearchPage component that scans translation resources
- register the `/search` route

## Testing
- `yarn lint` *(fails: Request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685a8bcc2f9883278b1cbd8845cce376