### PR TITLE
Fix ScrollToTop default parameter

### DIFF
--- a/src/components/scroll_to_top/ScrollToTop.tsx
+++ b/src/components/scroll_to_top/ScrollToTop.tsx
@@ -5,7 +5,7 @@ interface ScrollToTopProps {
   behavior?: ScrollBehavior; // 'auto' | 'smooth'
 }
 
-const ScrollToTop: React.FC<ScrollToTopProps> = ({ behavior = 'instant' }) => {
+const ScrollToTop: React.FC<ScrollToTopProps> = ({ behavior = 'auto' }) => {
   const { pathname } = useLocation();
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- correct the default behavior to a valid ScrollBehavior value

## Testing
- `yarn lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_685a89c5ad28832781c6b58596fae5a2