### PR TITLE
Fix English label in lang file

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -2,7 +2,7 @@
   "lang": "en",
   "navbar": {
     "romanian": "Romanian",
-    "english": "Enghish",
+    "english": "English",
     "russian": "Russian"
   },
   "general": {


### PR DESCRIPTION
## Summary
- correct the spelling for the English language label

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('src/lang/en.json','utf8')); console.log('JSON valid')"`
- `yarn lint` *(fails: cannot fetch yarn)*

------
https://chatgpt.com/codex/tasks/task_e_685a8f47d3c08327ac65fdba5357f2f7