### PR TITLE
Add translations for SMS Services tables

### DIFF
--- a/src/lang/ro.json
+++ b/src/lang/ro.json
@@ -1458,6 +1458,11 @@
       "title": "GPS Track",
       "description": "Soluție avansată de monitorizare GPS pentru flote, cu control în timp real și rapoarte detaliate.",
       "keywords": "gps track, flotă, monitorizare, localizare vehicule, mtrack"
+    },
+    "sms_services": {
+      "title": "SMS Service 100",
+      "description": "Activează rapid opțiuni și servicii Moldtelecom trimițând coduri SMS la numărul 100.",
+      "keywords": "sms service, opțiuni, pachete, internet, minute, roaming, moldtelecom, 100"
     }
   },
   "navbar_business": {
@@ -1648,6 +1653,94 @@
     "breadcrumb": {
       "mobile": "Mobil",
       "optionsandservices": "SMS Service"
+    },
+    "hero": { "alt": "Moldtelecom" },
+    "title_1": "Pentru utilizarea serviciului SMS Service 100 este suficientă expedierea de la telefonul tău mobil a unor SMS coduri la numărul scurt 100.",
+    "cards": {
+      "internet_packages": "Pachete internet",
+      "national_minutes": "Pachete minute naționale",
+      "international_packages": "Pachete internațional",
+      "roaming_world": "Roaming World",
+      "roaming_europe": "Roaming Europa",
+      "roaming_romania": "Roaming Romania",
+      "sms_packages": "Pachete SMS",
+      "account_status": "Starea contului",
+      "language_change": "Schimbarea limbei",
+      "fly_prepay_series": "Seria de opțiuni Fly Prepay",
+      "other_possibilities": "Alte posibilităţi"
+    },
+    "sms_text_html": "<br />Explicația simbolurilor utilizate în tabel:<br /><b>„n/a”</b> – nu se aplică;<br /><b>„*”</b> - cifrele codului Pin de pe cartela de reîncărcare Moldtelecom;<br /><b>„x”</b> - cifrele numărului de telefon al abonatului pentru care va fi aplicat serviciul, numărul de telefon va fi introdus cu prefixul “0”;<br /><b>„< >”</b> - câmpurile pentru care nu a fost definit câmpul cheie şi nu necesită de a fi utilizate la expedierea mesajului;<br /><b>„&nbsp;_”</b> - spaţiu liber.<br />Pentru întrebări suplimentare apelează Serviciul Asistență Clienți, formând numărul <a href=\"tel:1181\">1181</a> sau <a href=\"tel:022200200\">(022) 200 200</a>.",
+    "faq": {
+      "q1": "Cum pot afla numărul meu de telefon?",
+      "a1": "Trimite un SMS cu textul „NUMBER” la 100 și vei primi un mesaj cu numărul tău.",
+      "q2": "Cum pot reîncărca contul?",
+      "a2": "<ul><li>Pentru reîncărcare, trimite un SMS cu „R_************” (unde * reprezintă codul PIN de pe cartela de reîncărcare) la 100.</li><li>Pentru a cere unui prieten să îți reîncarce contul, trimite un SMS cu „RM_0xxxxxxxx” la 100 (unde „0xxxxxxxx” este numărul destinatarului).</li></ul>",
+      "q3": "Cum pot activa Roaming-ul UE sau World?",
+      "a3": "<div>Trimite SMS-ul corespunzător la 100, de exemplu:<ul><li>„UE100net” pentru 2GB internet roaming în UE (100 lei, 30 zile)</li><li>„Int30” pentru 30 de minute internaționale în România și Ucraina (50 lei, 30 zile).</li></ul></div>",
+      "q4": "Cum pot achita facturile Moldtelecom?",
+      "a4": "Facturile pot fi achitate online prin site-ul Moldtelecom, prin aplicația mobilă, la terminalele de plată, bănci partenere sau magazine Moldtelecom."
+    },
+    "tables": {
+      "internet": {
+        "title": "Pachete internet:",
+        "head_html": "<tr><td><strong>SMS cod</strong></td><td><strong>Descriere opțiune</strong></td><td><strong>Tarif</strong></td><td><strong>Valabilitate</strong></td></tr>",
+        "body_html": "<tr><td>Nelimitat1zi</td><td>Activare Internet Nelimitat o zi</td><td>20 lei</td><td>1 zi</td></tr><tr><td>Nelimitat/7</td><td>Activare Internet Nelimitat 7 zile</td><td>100 lei</td><td>7 zile</td></tr><tr><td>10GB/15</td><td>Internet 10 GB 15 zile</td><td>50 lei</td><td>15 zile</td></tr><tr><td>5GB/30</td><td>Internet 5 GB 30 zile</td><td>60 lei</td><td>30 zile</td></tr><tr><td>10GB</td><td>Internet 10 GB 30 zile</td><td>100 lei</td><td>30 zile</td></tr><tr><td>20GB</td><td>Internet 20 GB 30 zile</td><td>150 lei</td><td>30 zile</td></tr>"
+      },
+      "national_minutes": {
+        "title": "Pachete minute naționale:",
+        "head_html": "<tr><td><strong>SMS cod</strong></td><td><strong>Descriere opțiune</strong></td><td><strong>Tarif</strong></td><td><strong>Valabilitate</strong></td></tr>",
+        "body_html": "<tr><td>50min</td><td>50 minute naționale</td><td>15 lei</td><td>30 zile</td></tr><tr><td>100min</td><td>100 minute naționale</td><td>40 lei</td><td>30 zile</td></tr><tr><td>200min</td><td>200 minute naționale</td><td>70 lei</td><td>30 zile</td></tr>"
+      },
+      "international": {
+        "title": "Pachete internațional:",
+        "head_html": "<tr><td><strong> SMS cod</strong></td><td><strong>Descriere opțiune</strong></td><td><strong>Tarif&nbsp;&nbsp;</strong></td><td><strong>Conținut</strong></td><td><strong>Valabilitate</strong></td></tr>",
+        "body_html": "<tr><td>Int30</td><td>Activare România și Ucraina</td><td>50 lei</td><td>30 min.<br />internationale&nbsp;</td><td>30 zile</td></tr><tr><td>Int25</td><td>Activare Europa, Israel, SUA, Canada&nbsp; &nbsp;<br /><a href=\"https://moldtelecom.md/ru/Optiuni-telefonie-mobila\">(Mai multe detalii )</a></td><td>50 lei</td><td>25 min.<br />internationale</td><td>30 zile</td></tr><tr><td>Int10</td><td>Activare orice țară<br /><a href=\"https://moldtelecom.md/ro/apeluri-internationale\">(zona 1, zona 2, zona 3)</a></td><td>50 lei</td><td>10 min.<br />internationale</td><td>30 zile</td></tr>"
+      },
+      "roaming_world": {
+        "title": "ROAMING WORLD:",
+        "head_html": "<tr><td><strong>SMS cod</strong></td><td><strong>Descriere opțiune</strong></td><td><strong>Tarif&nbsp;</strong></td><td>Conținut</td><td><strong>Valabilitate</strong></td></tr>",
+        "body_html": "<tr><td>Wapel</td><td>Apeluri World</td><td>70 lei&nbsp;</td><td>10 min</td><td>30 zile</td></tr><tr><td>Wnet</td><td>Internet World</td><td>100 lei</td><td>1 GB</td><td>30 zile</td></tr>"
+      },
+      "roaming_europe": {
+        "title": "ROAMING Europa:",
+        "head_html": "<tr><td><strong>SMS cod</strong></td><td><strong>Descriere opțiune</strong></td><td>Trafic internet</td><td><strong>Tarif</strong></td><td><strong>Valabilitate</strong></td></tr>",
+        "body_html": "<tr><td>UE70apel</td><td>Apeluri Roaming UE</td><td>70 lei</td><td>100 min</td><td>30 zile</td></tr><tr><td>UE100net</td><td>Internet Roaming UE</td><td>100 lei</td><td>2 GB</td><td>30 zile</td></tr><tr><td>UE100</td><td>Combo Roaming UE</td><td>100 lei</td><td>50 min / 1 GB</td><td>30 zile</td></tr><tr><td>UE180</td><td>Connect Roaming UE</td><td>180 lei</td><td>50 min / 5 GB</td><td>30 zile</td></tr>"
+      },
+      "sms_packages": {
+        "title": "Pachete SMS:",
+        "head_html": "<tr><td><strong>SMS cod</strong></td><td><strong>Descriere opțiune</strong></td><td><strong>Tarif</strong></td><td><strong>Valabilitate</strong></td></tr>",
+        "body_html": "<tr><td>SMS50</td><td>50 SMS Naţionale</td><td>10 lei</td><td>30 zile</td></tr><tr><td>SMS35</td><td>20 SMS Internaționale</td><td>35 lei</td><td>30 zile</td></tr><tr><td>SMS15</td><td>100 SMS Naţionale&nbsp;</td><td>15 lei</td><td>30 zile</td></tr>"
+      },
+      "account_status": {
+        "title": "Starea contului:",
+        "head_html": "<tr><td><strong>SMS cod</strong></td><td><strong>Descriere opțiune</strong></td><td><strong>Tarif, lei</strong></td><td><strong>Valabilitate</strong></td></tr>",
+        "body_html": "<tr><td>OPTION</td><td>Verificarea opţiunilor activate</td><td>n/a</td><td>n/a</td></tr><tr><td>BONUS</td><td>Verificarea bonusului</td><td>n/a</td><td>n/a</td></tr><tr><td>LASTREC</td><td>Informaţii despre ultima reîncărcare</td><td>n/a</td><td>n/a</td></tr><tr><td>NUMBER</td><td>A afla numărul meu de telefon</td><td>n/a</td><td>n/a</td></tr>"
+      },
+      "language_change": {
+        "title": "Schimbarea limbei:",
+        "head_html": "<tr><td><strong>SMS cod</strong></td><td><strong>Descriere opțiune</strong></td><td><strong>Tarif, lei</strong></td><td><strong>Valabilitate</strong></td></tr>",
+        "body_html": "<tr><td>Lang_1</td><td>Limba Engleză</td><td>n/a</td><td>n/a</td></tr><tr><td>Lang_2</td><td>Limba Română</td><td>n/a</td><td>n/a</td></tr><tr><td>Lang_3</td><td>Limba Rusă</td><td>n/a</td><td>n/a</td></tr>"
+      },
+      "roaming_romania": {
+        "title": "Roaming Romania:",
+        "head_html": "<tr><td><strong>SMS cod</strong></td><td><strong>Descriere opțiune</strong></td><td>Trafic internet</td><td><strong>Tarif</strong></td><td><strong>Valabilitate</strong></td></tr>",
+        "body_html": "<tr><td>RO50</td><td>Roaming RO</td><td>50 lei</td><td>5 GB</td><td>30 zile</td></tr>"
+      },
+      "fly_prepay_series": {
+        "title": "Seria de opțiuni Fly Prepay:",
+        "head_html": "<tr><td><strong>SMS cod</strong></td><td><strong>Descriere opțiune&nbsp; &nbsp;</strong></td><td><strong>Minute naționale</strong></td><td><strong>Trafic internet</strong></td><td><strong>Tarif</strong></td><td><strong>Valabilitate</strong></td></tr>",
+        "body_html": "<tr><td><span><span><span>Fly 30</span></span></span></td><td>Fly Prepay 30</td><td>Nelimitat min. rețeaua mobilă/fixă Moldtelecom + 100&nbsp;minute către alți operatori&nbsp;</td><td>5 GB</td><td>30 lei</td><td>30 zile</td></tr><tr><td><span><span><span>Fly 50</span></span></span></td><td>Fly Prepay 50</td><td>250 minute rețeaua mobilă/fixă Moldtelecom + 250 minute către alți operatori&nbsp;</td><td>20 GB</td><td>50&nbsp; lei</td><td>15 zile</td></tr><tr><td><span><span><span>Fly 70</span></span></span></td><td>Fly Prepay 70</td><td>300 minute rețeaua mobilă/fixă Moldtelecom + 300 minute către alți operatori&nbsp;</td><td>25 GB</td><td>70 lei</td><td>30 zile</td></tr><tr><td><span><span><span>Fly&nbsp;100</span></span></span></td><td>Fly Prepay 100</td><td>Nelimitat minute rețeaua mobilă/fixă Moldtelecom + 300 minute către alți operatori</td><td>Nelimitat</td><td>100&nbsp;lei</td><td>15 zile</td></tr>"
+      },
+      "moldtelecom_talk": {
+        "title": "Moldtelecom Talk:",
+        "head_html": "<tr><td>SMS cod</td><td>Descriere opțiune</td><td>Tarif, lei</td><td>Valabilitate</td></tr>",
+        "body_html": "<tr><td>UT1</td><td>Activare Moldtelecom Talk</td><td>0</td><td>n/a</td></tr><tr><td>STOPUT1</td><td>Dezactivare Moldtelecom Talk</td><td>0</td><td>n/a</td></tr><tr><td>UT</td><td>Activare Moldtelecom Talk</td><td>0</td><td>n/a</td></tr><tr><td>STOPUT</td><td>Dezactivare Moldtelecom Talk</td><td>0</td><td>n/a</td></tr>"
+      },
+      "other_possibilities": {
+        "title": "Alte posibilităţi:",
+        "head_html": "<tr><td><strong>SMS cod</strong></td><td><strong>Descriere opțiune</strong></td><td><strong>Tarif, lei</strong></td><td><strong>Valabilitate</strong></td></tr>",
+        "body_html": "<tr><td>R_************</td><td>Suplinirea contului cu cartela de reîncărcare</td><td>n/a</td><td>n/a</td></tr><tr><td>RM_0xxxxxxxx</td><td>Expedierea SMS «Reîncarcă-mi contul» la un prieten (numai numere Moldtelecom), limita 5 sms per/zi</td><td>n/a</td><td>n/a</td></tr><tr><td>Callme_0xxxxxxxx</td><td>Expedierea SMS «Sună-mă» la un prieten (numai numere Moldtelecom), limita 5 sms per/zi</td><td>n/a</td><td>n/a</td></tr><tr><td>43_1</td><td>Activarea expedierii facturii prin email, modificarea va fi aplicată la următorul billing ciclu.</td><td>n/a</td><td>n/a</td></tr>"
+      }
     }
   }
 }

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -1493,6 +1493,11 @@
       "title": "GPS Track",
       "description": "Современное GPS-решение для мониторинга автопарков с контролем в реальном времени и подробными отчётами.",
       "keywords": "gps track, автопарк, мониторинг, отслеживание транспорта, mtrack"
+    },
+    "sms_services": {
+      "title": "SMS Service 100",
+      "description": "Быстро активируйте опции и услуги Moldtelecom, отправляя SMS‑коды на номер 100.",
+      "keywords": "sms service, опции, пакеты, интернет, минуты, роуминг, moldtelecom, 100"
     }
   },
   "home": {
@@ -1812,6 +1817,94 @@
     "breadcrumb": {
       "mobile": "Мобильный",
       "optionsandservices": "SMS Услуги"
+    },
+    "hero": { "alt": "Moldtelecom" },
+    "title_1": "Для использования услуги SMS Service 100 достаточно отправить с телефона SMS-код на короткий номер 100.",
+    "cards": {
+      "internet_packages": "Пакеты интернета",
+      "national_minutes": "Пакеты национальных минут",
+      "international_packages": "Международные пакеты",
+      "roaming_world": "Роуминг World",
+      "roaming_europe": "Роуминг Европа",
+      "roaming_romania": "Роуминг Румыния",
+      "sms_packages": "Пакеты SMS",
+      "account_status": "Состояние счета",
+      "language_change": "Смена языка",
+      "fly_prepay_series": "Опции Fly Prepay",
+      "other_possibilities": "Другие возможности"
+    },
+    "sms_text_html": "<br />Объяснение символов, используемых в таблице:<br /><b>«n/a»</b> – не применяется;<br /><b>«*»</b> - цифры PIN-кода с карты пополнения Moldtelecom;<br /><b>«x»</b> - цифры телефонного номера абонента, для которого будет применена услуга, номер вводится с префиксом «0»;<br /><b>«< >»</b> - поля, для которых не задан ключ, и их не нужно использовать при отправке сообщения;<br /><b>«&nbsp;_»</b> - пробел.<br />По дополнительным вопросам обращайтесь в Службу поддержки клиентов по номеру <a href=\"tel:1181\">1181</a> или <a href=\"tel:022200200\">(022) 200 200</a>.",
+    "faq": {
+      "q1": "Как узнать свой номер телефона?",
+      "a1": "Отправьте SMS с текстом «NUMBER» на номер 100 и получите сообщение с вашим номером.",
+      "q2": "Как пополнить счет?",
+      "a2": "<ul><li>Чтобы пополнить счет, отправьте SMS с «R_************» (где * — PIN-код с карты пополнения) на 100.</li><li>Чтобы попросить друга пополнить ваш счет, отправьте SMS с «RM_0xxxxxxxx» на 100 (где «0xxxxxxxx» — номер получателя).</li></ul>",
+      "q3": "Как активировать роуминг UE или World?",
+      "a3": "<div>Отправьте соответствующий SMS на 100, например:<ul><li>«UE100net» для 2GB интернет‑роуминга в ЕС (100 лей, 30 дней)</li><li>«Int30» для 30 международных минут в Румынию и Украину (50 лей, 30 дней).</li></ul></div>",
+      "q4": "Как оплатить счета Moldtelecom?",
+      "a4": "Счета можно оплатить онлайн на сайте Moldtelecom, через мобильное приложение, в платежных терминалах, партнерских банках или магазинах Moldtelecom."
+    },
+    "tables": {
+      "internet": {
+        "title": "Пакеты интернета:",
+        "head_html": "<tr><td><strong>SMS код</strong></td><td><strong>Описание опции</strong></td><td><strong>Тариф</strong></td><td><strong>Срок действия</strong></td></tr>",
+        "body_html": "<tr><td>Nelimitat1zi</td><td>Активация безлимитного интернета на 1 день</td><td>20 лей</td><td>1 день</td></tr><tr><td>Nelimitat/7</td><td>Активация безлимитного интернета на 7 дней</td><td>100 лей</td><td>7 дней</td></tr><tr><td>10GB/15</td><td>Интернет 10 ГБ 15 дней</td><td>50 лей</td><td>15 дней</td></tr><tr><td>5GB/30</td><td>Интернет 5 ГБ 30 дней</td><td>60 лей</td><td>30 дней</td></tr><tr><td>10GB</td><td>Интернет 10 ГБ 30 дней</td><td>100 лей</td><td>30 дней</td></tr><tr><td>20GB</td><td>Интернет 20 ГБ 30 дней</td><td>150 лей</td><td>30 дней</td></tr>"
+      },
+      "national_minutes": {
+        "title": "Пакеты национальных минут:",
+        "head_html": "<tr><td><strong>SMS код</strong></td><td><strong>Описание опции</strong></td><td><strong>Тариф</strong></td><td><strong>Срок действия</strong></td></tr>",
+        "body_html": "<tr><td>50min</td><td>50 национальных минут</td><td>15 лей</td><td>30 дней</td></tr><tr><td>100min</td><td>100 национальных минут</td><td>40 лей</td><td>30 дней</td></tr><tr><td>200min</td><td>200 национальных минут</td><td>70 лей</td><td>30 дней</td></tr>"
+      },
+      "international": {
+        "title": "Международные пакеты:",
+        "head_html": "<tr><td><strong> SMS код</strong></td><td><strong>Описание опции</strong></td><td><strong>Тариф&nbsp;&nbsp;</strong></td><td><strong>Содержание</strong></td><td><strong>Срок действия</strong></td></tr>",
+        "body_html": "<tr><td>Int30</td><td>Активация Румыния и Украина</td><td>50 лей</td><td>30 мин.<br />международные&nbsp;</td><td>30 дней</td></tr><tr><td>Int25</td><td>Активация Европа, Израиль, США, Канада&nbsp; &nbsp;<br /><a href=\"https://moldtelecom.md/ru/Optiuni-telefonie-mobila\">(Подробнее)</a></td><td>50 лей</td><td>25 мин.<br />международные</td><td>30 дней</td></tr><tr><td>Int10</td><td>Активация любая страна<br /><a href=\"https://moldtelecom.md/ro/apeluri-internationale\">(зона 1, зона 2, зона 3)</a></td><td>50 лей</td><td>10 мин.<br />международные</td><td>30 дней</td></tr>"
+      },
+      "roaming_world": {
+        "title": "РОУМИНГ WORLD:",
+        "head_html": "<tr><td><strong>SMS код</strong></td><td><strong>Описание опции</strong></td><td><strong>Тариф&nbsp;</strong></td><td>Содержание</td><td><strong>Срок действия</strong></td></tr>",
+        "body_html": "<tr><td>Wapel</td><td>Звонки World</td><td>70 лей&nbsp;</td><td>10 мин</td><td>30 дней</td></tr><tr><td>Wnet</td><td>Интернет World</td><td>100 лей</td><td>1 ГБ</td><td>30 дней</td></tr>"
+      },
+      "roaming_europe": {
+        "title": "РОУМИНГ Европа:",
+        "head_html": "<tr><td><strong>SMS код</strong></td><td><strong>Описание опции</strong></td><td>Трафик интернет</td><td><strong>Тариф</strong></td><td><strong>Срок действия</strong></td></tr>",
+        "body_html": "<tr><td>UE70apel</td><td>Звонки Roaming ЕС</td><td>70 лей</td><td>100 мин</td><td>30 дней</td></tr><tr><td>UE100net</td><td>Интернет Roaming ЕС</td><td>100 лей</td><td>2 ГБ</td><td>30 дней</td></tr><tr><td>UE100</td><td>Комбо Roaming ЕС</td><td>100 лей</td><td>50 мин / 1 ГБ</td><td>30 дней</td></tr><tr><td>UE180</td><td>Connect Roaming ЕС</td><td>180 лей</td><td>50 мин / 5 ГБ</td><td>30 дней</td></tr>"
+      },
+      "sms_packages": {
+        "title": "Пакеты SMS:",
+        "head_html": "<tr><td><strong>SMS код</strong></td><td><strong>Описание опции</strong></td><td><strong>Тариф</strong></td><td><strong>Срок действия</strong></td></tr>",
+        "body_html": "<tr><td>SMS50</td><td>50 национальных SMS</td><td>10 лей</td><td>30 дней</td></tr><tr><td>SMS35</td><td>20 международных SMS</td><td>35 лей</td><td>30 дней</td></tr><tr><td>SMS15</td><td>100 национальных SMS</td><td>15 лей</td><td>30 дней</td></tr>"
+      },
+      "account_status": {
+        "title": "Состояние счета:",
+        "head_html": "<tr><td><strong>SMS код</strong></td><td><strong>Описание опции</strong></td><td><strong>Тариф, лей</strong></td><td><strong>Срок действия</strong></td></tr>",
+        "body_html": "<tr><td>OPTION</td><td>Проверка активированных опций</td><td>n/a</td><td>n/a</td></tr><tr><td>BONUS</td><td>Проверка бонуса</td><td>n/a</td><td>n/a</td></tr><tr><td>LASTREC</td><td>Информация о последнем пополнении</td><td>n/a</td><td>n/a</td></tr><tr><td>NUMBER</td><td>Узнать свой номер телефона</td><td>n/a</td><td>n/a</td></tr>"
+      },
+      "language_change": {
+        "title": "Смена языка:",
+        "head_html": "<tr><td><strong>SMS код</strong></td><td><strong>Описание опции</strong></td><td><strong>Тариф, лей</strong></td><td><strong>Срок действия</strong></td></tr>",
+        "body_html": "<tr><td>Lang_1</td><td>Английский язык</td><td>n/a</td><td>n/a</td></tr><tr><td>Lang_2</td><td>Румынский язык</td><td>n/a</td><td>n/a</td></tr><tr><td>Lang_3</td><td>Русский язык</td><td>n/a</td><td>n/a</td></tr>"
+      },
+      "roaming_romania": {
+        "title": "Роуминг Румыния:",
+        "head_html": "<tr><td><strong>SMS код</strong></td><td><strong>Описание опции</strong></td><td>Трафик интернет</td><td><strong>Тариф</strong></td><td><strong>Срок действия</strong></td></tr>",
+        "body_html": "<tr><td>RO50</td><td>Роуминг RO</td><td>50 лей</td><td>5 ГБ</td><td>30 дней</td></tr>"
+      },
+      "fly_prepay_series": {
+        "title": "Опции Fly Prepay:",
+        "head_html": "<tr><td><strong>SMS код</strong></td><td><strong>Описание опции&nbsp; &nbsp;</strong></td><td><strong>Национальные минуты</strong></td><td><strong>Трафик интернет</strong></td><td><strong>Тариф</strong></td><td><strong>Срок действия</strong></td></tr>",
+        "body_html": "<tr><td><span><span><span>Fly 30</span></span></span></td><td>Fly Prepay 30</td><td>Безлимит мин. сеть Moldtelecom + 100 минут другим операторам&nbsp;</td><td>5 GB</td><td>30 лей</td><td>30 дней</td></tr><tr><td><span><span><span>Fly 50</span></span></span></td><td>Fly Prepay 50</td><td>250 минут сеть Moldtelecom + 250 минут другим операторам&nbsp;</td><td>20 GB</td><td>50 лей</td><td>15 дней</td></tr><tr><td><span><span><span>Fly 70</span></span></span></td><td>Fly Prepay 70</td><td>300 минут сеть Moldtelecom + 300 минут другим операторам&nbsp;</td><td>25 GB</td><td>70 лей</td><td>30 дней</td></tr><tr><td><span><span><span>Fly&nbsp;100</span></span></span></td><td>Fly Prepay 100</td><td>Безлимит минут сеть Moldtelecom + 300 минут другим операторам</td><td>Безлимит</td><td>100 лей</td><td>15 дней</td></tr>"
+      },
+      "moldtelecom_talk": {
+        "title": "Moldtelecom Talk:",
+        "head_html": "<tr><td>SMS код</td><td>Описание опции</td><td>Тариф, лей</td><td>Срок действия</td></tr>",
+        "body_html": "<tr><td>UT1</td><td>Активация Moldtelecom Talk</td><td>0</td><td>n/a</td></tr><tr><td>STOPUT1</td><td>Деактивация Moldtelecom Talk</td><td>0</td><td>n/a</td></tr><tr><td>UT</td><td>Активация Moldtelecom Talk</td><td>0</td><td>n/a</td></tr><tr><td>STOPUT</td><td>Деактивация Moldtelecom Talk</td><td>0</td><td>n/a</td></tr>"
+      },
+      "other_possibilities": {
+        "title": "Другие возможности:",
+        "head_html": "<tr><td><strong>SMS код</strong></td><td><strong>Описание опции</strong></td><td><strong>Тариф, лей</strong></td><td><strong>Срок действия</strong></td></tr>",
+        "body_html": "<tr><td>R_************</td><td>Пополнение счёта картой пополнения</td><td>n/a</td><td>n/a</td></tr><tr><td>RM_0xxxxxxxx</td><td>Отправить SMS «Пополните мой счёт» другу (только номера Moldtelecom), лимит 5 sms/день</td><td>n/a</td><td>n/a</td></tr><tr><td>Callme_0xxxxxxxx</td><td>Отправить SMS «Позвони мне» другу (только номера Moldtelecom), лимит 5 sms/день</td><td>n/a</td><td>n/a</td></tr><tr><td>43_1</td><td>Активировать отправку счета по email, изменение будет применено в следующем биллинговом цикле.</td><td>n/a</td><td>n/a</td></tr>"
+      }
     }
   }
 }

--- a/src/pages/personal/oferte/sms_services/SmsServices.tsx
+++ b/src/pages/personal/oferte/sms_services/SmsServices.tsx
@@ -39,24 +39,23 @@ export default function SmsServices() {
           <img
             className={styles.hero_img}
             src={`/images/landings/18074332${t('lang')}.webp`}
-            alt="Moldtelecom"
+            alt={t('sms_services.hero.alt')}
           />
           <img
             className={styles.hero_img_tablet}
             src={`/images/landings/16074571${t('lang')}.webp`}
-            alt="Moldtelecom"
+            alt={t('sms_services.hero.alt')}
           />
         </div>
       </Hero>
-      <div className={styles.sms_title_1}>
-        Pentru utilizarea serviciului SMS Service 100 este suficientă expedierea
-        de la telefonul tău mobil a unor SMS coduri la numărul scurt 100.
-      </div>
+      <div className={styles.sms_title_1}>{t('sms_services.title_1')}</div>
 
       <div className={styles.cards}>
         <div className={styles.card}>
           <img src="/images/landings/10171083.webp" alt="Moldtelecom" />
-          <div className={styles.card_title}>Pachete internet</div>
+          <div className={styles.card_title}>
+            {t('sms_services.cards.internet_packages')}
+          </div>
           <Button
             onClick={() => {
               setActivePopup('1251120');
@@ -73,7 +72,9 @@ export default function SmsServices() {
         </div>
         <div className={styles.card}>
           <img src="/images/landings/20771083.webp" alt="Moldtelecom" />
-          <div className={styles.card_title}>Pachete minute naționale</div>
+          <div className={styles.card_title}>
+            {t('sms_services.cards.national_minutes')}
+          </div>
           <Button
             onClick={() => {
               setActivePopup('1251121');
@@ -90,7 +91,9 @@ export default function SmsServices() {
         </div>
         <div className={styles.card}>
           <img src="/images/landings/10571083.webp" alt="Moldtelecom" />
-          <div className={styles.card_title}>Pachete internațional</div>
+          <div className={styles.card_title}>
+            {t('sms_services.cards.international_packages')}
+          </div>
           <Button
             onClick={() => {
               setActivePopup('1251122');
@@ -107,7 +110,9 @@ export default function SmsServices() {
         </div>
         <div className={styles.card}>
           <img src="/images/landings/15172083.webp" alt="Moldtelecom" />
-          <div className={styles.card_title}>Roaming World</div>
+          <div className={styles.card_title}>
+            {t('sms_services.cards.roaming_world')}
+          </div>
           <Button
             onClick={() => {
               setActivePopup('1251123');
@@ -124,7 +129,9 @@ export default function SmsServices() {
         </div>
         <div className={styles.card}>
           <img src="/images/landings/15672983.webp" alt="Moldtelecom" />
-          <div className={styles.card_title}>Roaming Europa</div>
+          <div className={styles.card_title}>
+            {t('sms_services.cards.roaming_europe')}
+          </div>
           <Button
             onClick={() => {
               setActivePopup('1251124');
@@ -141,7 +148,9 @@ export default function SmsServices() {
         </div>
         <div className={styles.card}>
           <img src="/images/landings/15672984.webp" alt="Moldtelecom" />
-          <div className={styles.card_title}>Roaming Romania</div>
+          <div className={styles.card_title}>
+            {t('sms_services.cards.roaming_romania')}
+          </div>
           <Button
             onClick={() => {
               setActivePopup('1251129');
@@ -158,7 +167,9 @@ export default function SmsServices() {
         </div>
         <div className={styles.card}>
           <img src="/images/landings/69171082.webp" alt="Moldtelecom" />
-          <div className={styles.card_title}>Pachete SMS</div>
+          <div className={styles.card_title}>
+            {t('sms_services.cards.sms_packages')}
+          </div>
           <Button
             onClick={() => {
               setActivePopup('1251125');
@@ -175,7 +186,9 @@ export default function SmsServices() {
         </div>
         <div className={styles.card}>
           <img src="/images/landings/15672989.webp" alt="Moldtelecom" />
-          <div className={styles.card_title}>Starea contului</div>
+          <div className={styles.card_title}>
+            {t('sms_services.cards.account_status')}
+          </div>
           <Button
             onClick={() => {
               setActivePopup('1251126');
@@ -192,7 +205,9 @@ export default function SmsServices() {
         </div>
         <div className={styles.card}>
           <img src="/images/landings/10571085.webp" alt="Moldtelecom" />
-          <div className={styles.card_title}>Schimbarea limbei</div>
+          <div className={styles.card_title}>
+            {t('sms_services.cards.language_change')}
+          </div>
 
           <Button
             onClick={() => {
@@ -210,7 +225,9 @@ export default function SmsServices() {
         </div>
         <div className={styles.card}>
           <img src="/images/landings/20771088.webp" alt="Moldtelecom" />
-          <div className={styles.card_title}>Seria de opțiuni Fly Prepay</div>
+          <div className={styles.card_title}>
+            {t('sms_services.cards.fly_prepay_series')}
+          </div>
 
           <Button
             onClick={() => {
@@ -247,7 +264,9 @@ export default function SmsServices() {
 
         <div className={`${styles.card} ${styles.card_white}`}>
           <img src="/images/landings/18171083.webp" alt="Moldtelecom" />
-          <div className={styles.card_title}>Alte posibilităţi</div>
+          <div className={styles.card_title}>
+            {t('sms_services.cards.other_possibilities')}
+          </div>
           <Button
             onClick={() => {
               setActivePopup('1251131');
@@ -264,72 +283,24 @@ export default function SmsServices() {
         </div>
       </div>
 
-      <div className={styles.sms_text}>
-        <br />
-        Explicația simbolurilor utilizate în tabel:
-        <br />
-        <b>„n/a”</b> – nu se aplică;
-        <br />
-        <b>„*”</b> - cifrele codului Pin de pe cartela de reîncărcare
-        Moldtelecom;
-        <br />
-        <b>„x”</b> - cifrele numărului de telefon al abonatului pentru care va
-        fi aplicat serviciul, numărul de telefon va fi introdus cu prefixul “0”;
-        <br />
-        <b>„&lt; &gt;”</b> - câmpurile pentru care nu a fost definit câmpul
-        cheie şi nu necesită de a fi utilizate la expedierea mesajului;
-        <br />
-        <b>„&nbsp;_”</b> - spaţiu liber.
-        <br />
-        Pentru întrebări suplimentare apelează Serviciul Asistență Clienți,
-        formând numărul <a href="tel:1181">1181</a> sau{' '}
-        <a href="tel:022200200">(022) 200 200</a>.
-      </div>
+      <div
+        className={styles.sms_text}
+        dangerouslySetInnerHTML={{ __html: t('sms_services.sms_text_html') }}
+      />
 
       {/* FAQ */}
       <FaqV2 max_faq={6}>
-        <FaqQAV2
-          question={'Cum pot afla numărul meu de telefon?'}
-          id_faq={'126489311'}
-        >
-          Trimite un SMS cu textul „NUMBER” la 100 și vei primi un mesaj cu
-          numărul tău.
+        <FaqQAV2 question={t('sms_services.faq.q1')} id_faq={'126489311'}>
+          {t('sms_services.faq.a1')}
         </FaqQAV2>
-        <FaqQAV2 question={'Cum pot reîncărca contul?'} id_faq={'126489312'}>
-          <ul>
-            <li>
-              Pentru reîncărcare, trimite un SMS cu „R_************” (unde *
-              reprezintă codul PIN de pe cartela de reîncărcare) la 100.
-            </li>
-            <li>
-              Pentru a cere unui prieten să îți reîncarce contul, trimite un SMS
-              cu „RM_0xxxxxxxx” la 100 (unde „0xxxxxxxx” este numărul
-              destinatarului).
-            </li>
-          </ul>
+        <FaqQAV2 question={t('sms_services.faq.q2')} id_faq={'126489312'}>
+          <div dangerouslySetInnerHTML={{ __html: t('sms_services.faq.a2') }} />
         </FaqQAV2>
-        <FaqQAV2
-          question={' Cum pot activa Roaming-ul UE sau World?'}
-          id_faq={'126489313'}
-        >
-          Trimite SMS-ul corespunzător la 100, de exemplu:
-          <ul>
-            <li>
-              „UE100net” pentru 2GB internet roaming în UE (100 lei, 30 zile)
-            </li>
-            <li>
-              „Int30” pentru 30 de minute internaționale în România și Ucraina
-              (50 lei, 30 zile).
-            </li>
-          </ul>
+        <FaqQAV2 question={t('sms_services.faq.q3')} id_faq={'126489313'}>
+          <div dangerouslySetInnerHTML={{ __html: t('sms_services.faq.a3') }} />
         </FaqQAV2>
-        <FaqQAV2
-          question={' Cum pot achita facturile Moldtelecom?'}
-          id_faq={'126489314'}
-        >
-          Facturile pot fi achitate online prin site-ul Moldtelecom, prin
-          aplicația mobilă, la terminalele de plată, bănci partenere sau
-          magazine Moldtelecom.
+        <FaqQAV2 question={t('sms_services.faq.q4')} id_faq={'126489314'}>
+          {t('sms_services.faq.a4')}
         </FaqQAV2>
       </FaqV2>
 
@@ -341,76 +312,23 @@ export default function SmsServices() {
         isVisible={activePopup === '1251120'}
         onClose={() => setActivePopup(null)}
       >
-        <div className={styles.popup_title}>Pachete internet:</div>
+        <div className={styles.popup_title}>
+          {t('sms_services.tables.internet.title')}
+        </div>
 
         <ScrollableWrapper>
           <table className="popup_table">
-            <thead>
-              <tr>
-                <td>
-                  <strong>SMS cod</strong>
-                </td>
-                <td>
-                  <strong>Descriere opțiune</strong>
-                </td>
-                <td>
-                  <strong>Tarif</strong>
-                </td>
-                <td>
-                  <strong>Valabilitate</strong>
-                </td>
-              </tr>
-            </thead>
-            <tbody className={styles.popup_table_body}>
-              <tr>
-                <td>Nelimitat1zi</td>
-                <td>Activare Internet Nelimitat o zi</td>
-                <td>20 lei</td>
-                <td>1 zi</td>
-              </tr>
-              <tr>
-                <td>Nelimitat/7</td>
-                <td>Activare Internet Nelimitat 7 zile</td>
-                <td>100 lei</td>
-                <td>7 zile</td>
-              </tr>
-              <tr>
-                <td>10GB/15</td>
-                <td>Internet 10 GB 15 zile</td>
-                <td>50 lei</td>
-                <td>15 zile</td>
-              </tr>
-              <tr>
-                <td>5GB/30</td>
-                <td>
-                  Internet 5 GB 30<span>&nbsp;zile</span>
-                </td>
-                <td>60 lei</td>
-                <td>30 zile</td>
-              </tr>
-              <tr>
-                <td>10GB</td>
-                <td>
-                  Internet 10 GB&nbsp;
-                  <span>
-                    30<span>&nbsp;zile</span>
-                  </span>
-                </td>
-                <td>100 lei</td>
-                <td>30 zile</td>
-              </tr>
-              <tr>
-                <td>20GB</td>
-                <td>
-                  Internet 20 GB&nbsp;
-                  <span>
-                    30<span>&nbsp;zile</span>
-                  </span>
-                </td>
-                <td>150 lei</td>
-                <td>30 zile</td>
-              </tr>
-            </tbody>
+            <thead
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.internet.head_html'),
+              }}
+            />
+            <tbody
+              className={styles.popup_table_body}
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.internet.body_html'),
+              }}
+            />
           </table>
         </ScrollableWrapper>
       </Popup>
@@ -420,46 +338,23 @@ export default function SmsServices() {
         isVisible={activePopup === '1251121'}
         onClose={() => setActivePopup(null)}
       >
-        <div className={styles.popup_title}>Pachete minute naționale:</div>
+        <div className={styles.popup_title}>
+          {t('sms_services.tables.national_minutes.title')}
+        </div>
 
         <ScrollableWrapper>
           <table className="popup_table">
-            <thead>
-              <tr>
-                <td>
-                  <strong>SMS cod</strong>
-                </td>
-                <td>
-                  <strong>Descriere opțiune</strong>
-                </td>
-                <td>
-                  <strong>Tarif</strong>
-                </td>
-                <td>
-                  <strong>Valabilitate</strong>
-                </td>
-              </tr>
-            </thead>
-            <tbody className={styles.popup_table_body}>
-              <tr>
-                <td>50min</td>
-                <td>50 minute naționale</td>
-                <td>15 lei</td>
-                <td>30 zile</td>
-              </tr>
-              <tr>
-                <td>100min</td>
-                <td>100 minute naționale</td>
-                <td>40 lei</td>
-                <td>30 zile</td>
-              </tr>
-              <tr>
-                <td>200min</td>
-                <td>200 minute naționale</td>
-                <td>70 lei</td>
-                <td>30 zile</td>
-              </tr>
-            </tbody>
+            <thead
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.national_minutes.head_html'),
+              }}
+            />
+            <tbody
+              className={styles.popup_table_body}
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.national_minutes.body_html'),
+              }}
+            />
           </table>
         </ScrollableWrapper>
       </Popup>
@@ -469,76 +364,23 @@ export default function SmsServices() {
         isVisible={activePopup === '1251122'}
         onClose={() => setActivePopup(null)}
       >
-        <div className={styles.popup_title}>Pachete internațional:</div>
+        <div className={styles.popup_title}>
+          {t('sms_services.tables.international.title')}
+        </div>
 
         <ScrollableWrapper>
           <table className="popup_table">
-            <thead>
-              <tr>
-                <td>
-                  <strong> SMS cod</strong>
-                </td>
-                <td>
-                  <strong>Descriere opțiune</strong>
-                </td>
-                <td>
-                  <strong>Tarif&nbsp;&nbsp;</strong>
-                </td>
-                <td>
-                  <strong>Conținut</strong>
-                </td>
-                <td>
-                  <strong>Valabilitate</strong>
-                </td>
-              </tr>
-            </thead>
-            <tbody className={styles.popup_table_body}>
-              <tr>
-                <td>Int30</td>
-                <td>Activare România și Ucraina</td>
-                <td>50 lei</td>
-                <td>
-                  30 min.
-                  <br />
-                  internationale&nbsp;
-                </td>
-                <td>30 zile</td>
-              </tr>
-              <tr>
-                <td>Int25</td>
-                <td>
-                  Activare Europa, Israel, SUA, Canada&nbsp; &nbsp;
-                  <br />
-                  <a href="https://moldtelecom.md/ru/Optiuni-telefonie-mobila">
-                    (Mai multe detalii )
-                  </a>
-                </td>
-                <td>50 lei</td>
-                <td>
-                  25 min.
-                  <br />
-                  internationale
-                </td>
-                <td>30 zile</td>
-              </tr>
-              <tr>
-                <td>Int10</td>
-                <td>
-                  Activare orice țară
-                  <br />
-                  <a href="https://moldtelecom.md/ro/apeluri-internationale">
-                    (zona 1, zona 2, zona 3)
-                  </a>
-                </td>
-                <td>50 lei</td>
-                <td>
-                  10 min.
-                  <br />
-                  internationale
-                </td>
-                <td>30 zile</td>
-              </tr>
-            </tbody>
+            <thead
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.international.head_html'),
+              }}
+            />
+            <tbody
+              className={styles.popup_table_body}
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.international.body_html'),
+              }}
+            />
           </table>
         </ScrollableWrapper>
       </Popup>
@@ -548,46 +390,23 @@ export default function SmsServices() {
         isVisible={activePopup === '1251123'}
         onClose={() => setActivePopup(null)}
       >
-        <div className={styles.popup_title}>ROAMING WORLD:</div>
+        <div className={styles.popup_title}>
+          {t('sms_services.tables.roaming_world.title')}
+        </div>
 
         <ScrollableWrapper>
           <table className="popup_table">
-            <thead>
-              <tr>
-                <td>
-                  <strong>S</strong>
-                  <strong>
-                    <strong>M</strong>S cod
-                  </strong>
-                </td>
-                <td>
-                  <strong>Descriere opțiune</strong>
-                </td>
-                <td>
-                  <strong>Tarif&nbsp;</strong>
-                </td>
-                <td>Conținut</td>
-                <td>
-                  <strong>Valabilitate</strong>
-                </td>
-              </tr>
-            </thead>
-            <tbody className={styles.popup_table_body}>
-              <tr>
-                <td>Wapel</td>
-                <td>Apeluri World</td>
-                <td>70 lei&nbsp;</td>
-                <td>10 min</td>
-                <td>30 zile</td>
-              </tr>
-              <tr>
-                <td>Wnet</td>
-                <td>Internet World</td>
-                <td>100 lei</td>
-                <td>1 GB</td>
-                <td>30 zile</td>
-              </tr>
-            </tbody>
+            <thead
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.roaming_world.head_html'),
+              }}
+            />
+            <tbody
+              className={styles.popup_table_body}
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.roaming_world.body_html'),
+              }}
+            />
           </table>
         </ScrollableWrapper>
       </Popup>
@@ -597,57 +416,23 @@ export default function SmsServices() {
         isVisible={activePopup === '1251124'}
         onClose={() => setActivePopup(null)}
       >
-        <div className={styles.popup_title}>ROAMING Europa:</div>
+        <div className={styles.popup_title}>
+          {t('sms_services.tables.roaming_europe.title')}
+        </div>
 
         <ScrollableWrapper>
           <table className="popup_table">
-            <thead>
-              <tr>
-                <td>
-                  <strong>SMS cod</strong>
-                </td>
-                <td>
-                  <strong>Descriere opțiune</strong>
-                </td>
-                <td>Trafic internet</td>
-                <td>
-                  <strong>Tarif</strong>
-                </td>
-                <td>
-                  <strong>Valabilitate</strong>
-                </td>
-              </tr>
-            </thead>
-            <tbody className={styles.popup_table_body}>
-              <tr>
-                <td>UE70apel</td>
-                <td>Apeluri Roaming UE</td>
-                <td>70 lei</td>
-                <td>100 min</td>
-                <td>30 zile</td>
-              </tr>
-              <tr>
-                <td>UE100net</td>
-                <td>Internet Roaming UE</td>
-                <td>100 lei</td>
-                <td>2 GB</td>
-                <td>30 zile</td>
-              </tr>
-              <tr>
-                <td>UE100</td>
-                <td>Combo Roaming UE</td>
-                <td>100 lei</td>
-                <td>50 min / 1 GB</td>
-                <td>30 zile</td>
-              </tr>
-              <tr>
-                <td>UE180</td>
-                <td>Connect Roaming UE</td>
-                <td>180 lei</td>
-                <td>50 min / 5 GB</td>
-                <td>30 zile</td>
-              </tr>
-            </tbody>
+            <thead
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.roaming_europe.head_html'),
+              }}
+            />
+            <tbody
+              className={styles.popup_table_body}
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.roaming_europe.body_html'),
+              }}
+            />
           </table>
         </ScrollableWrapper>
       </Popup>
@@ -657,46 +442,23 @@ export default function SmsServices() {
         isVisible={activePopup === '1251125'}
         onClose={() => setActivePopup(null)}
       >
-        <div className={styles.popup_title}>Pachete SMS:</div>
+        <div className={styles.popup_title}>
+          {t('sms_services.tables.sms_packages.title')}
+        </div>
 
         <ScrollableWrapper>
           <table className="popup_table">
-            <thead>
-              <tr>
-                <td>
-                  <strong>SMS cod</strong>
-                </td>
-                <td>
-                  <strong>Descriere opțiune</strong>
-                </td>
-                <td>
-                  <strong>Tarif</strong>
-                </td>
-                <td>
-                  <strong>Valabilitate</strong>
-                </td>
-              </tr>
-            </thead>
-            <tbody className={styles.popup_table_body}>
-              <tr>
-                <td>SMS50</td>
-                <td>50 SMS Naţionale</td>
-                <td>10&nbsp; lei</td>
-                <td>30 zile</td>
-              </tr>
-              <tr>
-                <td>SMS35</td>
-                <td>20 SMS Internaționale</td>
-                <td>35&nbsp; lei</td>
-                <td>30 zile</td>
-              </tr>
-              <tr>
-                <td>SMS15</td>
-                <td>100 SMS Naţionale&nbsp;</td>
-                <td>15&nbsp; lei</td>
-                <td>30 zile</td>
-              </tr>
-            </tbody>
+            <thead
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.sms_packages.head_html'),
+              }}
+            />
+            <tbody
+              className={styles.popup_table_body}
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.sms_packages.body_html'),
+              }}
+            />
           </table>
         </ScrollableWrapper>
       </Popup>
@@ -706,52 +468,23 @@ export default function SmsServices() {
         isVisible={activePopup === '1251126'}
         onClose={() => setActivePopup(null)}
       >
-        <div className={styles.popup_title}>Starea contului:</div>
+        <div className={styles.popup_title}>
+          {t('sms_services.tables.account_status.title')}
+        </div>
 
         <ScrollableWrapper>
           <table className="popup_table">
-            <thead>
-              <tr>
-                <td>
-                  <strong>SMS cod</strong>
-                </td>
-                <td>
-                  <strong>Descriere opțiune</strong>
-                </td>
-                <td>
-                  <strong>Tarif, lei</strong>
-                </td>
-                <td>
-                  <strong>Valabilitate</strong>
-                </td>
-              </tr>
-            </thead>
-            <tbody className={styles.popup_table_body}>
-              <tr>
-                <td>OPTION</td>
-                <td>Verificarea opţiunilor activate</td>
-                <td>n/a</td>
-                <td>n/a</td>
-              </tr>
-              <tr>
-                <td>BONUS</td>
-                <td>Verificarea bonusului</td>
-                <td>n/a</td>
-                <td>n/a</td>
-              </tr>
-              <tr>
-                <td>LASTREC</td>
-                <td>Informaţii despre ultima reîncărcare</td>
-                <td>n/a</td>
-                <td>n/a</td>
-              </tr>
-              <tr>
-                <td>NUMBER</td>
-                <td>A afla numărul meu de telefon</td>
-                <td>n/a</td>
-                <td>n/a</td>
-              </tr>
-            </tbody>
+            <thead
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.account_status.head_html'),
+              }}
+            />
+            <tbody
+              className={styles.popup_table_body}
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.account_status.body_html'),
+              }}
+            />
           </table>
         </ScrollableWrapper>
       </Popup>
@@ -761,46 +494,23 @@ export default function SmsServices() {
         isVisible={activePopup === '1251127'}
         onClose={() => setActivePopup(null)}
       >
-        <div className={styles.popup_title}>Schimbarea limbei:</div>
+        <div className={styles.popup_title}>
+          {t('sms_services.tables.language_change.title')}
+        </div>
 
         <ScrollableWrapper>
           <table className="popup_table">
-            <thead>
-              <tr>
-                <td>
-                  <strong>SMS cod</strong>
-                </td>
-                <td>
-                  <strong>Descriere opțiune</strong>
-                </td>
-                <td>
-                  <strong>Tarif, lei</strong>
-                </td>
-                <td>
-                  <strong>Valabilitate</strong>
-                </td>
-              </tr>
-            </thead>
-            <tbody className={styles.popup_table_body}>
-              <tr>
-                <td>Lang_1</td>
-                <td>Limba Engleză</td>
-                <td>n/a</td>
-                <td>n/a</td>
-              </tr>
-              <tr>
-                <td>Lang_2</td>
-                <td>Limba Română</td>
-                <td>n/a</td>
-                <td>n/a</td>
-              </tr>
-              <tr>
-                <td>Lang_3</td>
-                <td>Limba Rusă</td>
-                <td>n/a</td>
-                <td>n/a</td>
-              </tr>
-            </tbody>
+            <thead
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.language_change.head_html'),
+              }}
+            />
+            <tbody
+              className={styles.popup_table_body}
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.language_change.body_html'),
+              }}
+            />
           </table>
         </ScrollableWrapper>
       </Popup>
@@ -810,36 +520,23 @@ export default function SmsServices() {
         isVisible={activePopup === '1251129'}
         onClose={() => setActivePopup(null)}
       >
-        <div className={styles.popup_title}>Roaming Romania:</div>
+        <div className={styles.popup_title}>
+          {t('sms_services.tables.roaming_romania.title')}
+        </div>
 
         <ScrollableWrapper>
           <table className="popup_table">
-            <thead>
-              <tr>
-                <td>
-                  <strong>SMS cod</strong>
-                </td>
-                <td>
-                  <strong>Descriere opțiune</strong>
-                </td>
-                <td>Trafic internet</td>
-                <td>
-                  <strong>Tarif</strong>
-                </td>
-                <td>
-                  <strong>Valabilitate</strong>
-                </td>
-              </tr>
-            </thead>
-            <tbody className={styles.popup_table_body}>
-              <tr>
-                <td>RO50</td>
-                <td>Roaming RO</td>
-                <td>50 lei</td>
-                <td>5 GB</td>
-                <td>30 zile</td>
-              </tr>
-            </tbody>
+            <thead
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.roaming_romania.head_html'),
+              }}
+            />
+            <tbody
+              className={styles.popup_table_body}
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.roaming_romania.body_html'),
+              }}
+            />
           </table>
         </ScrollableWrapper>
       </Popup>
@@ -849,102 +546,23 @@ export default function SmsServices() {
         isVisible={activePopup === '1251130'}
         onClose={() => setActivePopup(null)}
       >
-        <div className={styles.popup_title}>Seria de opțiuni Fly Prepay:</div>
+        <div className={styles.popup_title}>
+          {t('sms_services.tables.fly_prepay_series.title')}
+        </div>
 
         <ScrollableWrapper>
           <table className="popup_table">
-            <thead>
-              <tr>
-                <td>
-                  <strong>SMS cod</strong>
-                </td>
-                <td>
-                  <strong>Descriere opțiune&nbsp; &nbsp;</strong>
-                </td>
-                <td>
-                  <strong>Minute naționale</strong>
-                </td>
-                <td>
-                  <strong>Trafic internet</strong>
-                </td>
-                <td>
-                  <strong>Tarif</strong>
-                </td>
-                <td>
-                  <strong>Valabilitate</strong>
-                </td>
-              </tr>
-            </thead>
-            <tbody className={styles.popup_table_body}>
-              <tr>
-                <td>
-                  <span>
-                    <span>
-                      <span>Fly 30</span>
-                    </span>
-                  </span>
-                </td>
-                <td>Fly Prepay 30</td>
-                <td>
-                  Nelimitat min. rețeaua mobilă/fixă Moldtelecom + 100&nbsp;
-                  minute către alți operatori&nbsp;
-                </td>
-                <td>5 GB</td>
-                <td>30 lei</td>
-                <td>30 zile</td>
-              </tr>
-              <tr>
-                <td>
-                  <span>
-                    <span>
-                      <span>Fly 50</span>
-                    </span>
-                  </span>
-                </td>
-                <td>Fly Prepay 50</td>
-                <td>
-                  250 minute rețeaua mobilă/fixă Moldtelecom + 250 minute către
-                  alți operatori&nbsp;
-                </td>
-                <td>20 GB</td>
-                <td>50&nbsp; lei</td>
-                <td>15 zile</td>
-              </tr>
-              <tr>
-                <td>
-                  <span>
-                    <span>
-                      <span>Fly 70</span>
-                    </span>
-                  </span>
-                </td>
-                <td>Fly Prepay 70</td>
-                <td>
-                  300 minute rețeaua mobilă/fixă Moldtelecom + 300 minute către
-                  alți operatori&nbsp;
-                </td>
-                <td>25 GB</td>
-                <td>70 lei</td>
-                <td>30 zile</td>
-              </tr>
-              <tr>
-                <td>
-                  <span>
-                    <span>
-                      <span>Fly&nbsp;100</span>
-                    </span>
-                  </span>
-                </td>
-                <td>Fly Prepay 100</td>
-                <td>
-                  Nelimitat minute rețeaua mobilă/fixă Moldtelecom + 300 minute
-                  către alți operatori
-                </td>
-                <td>Nelimitat</td>
-                <td>100&nbsp;lei</td>
-                <td>15 zile</td>
-              </tr>
-            </tbody>
+            <thead
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.fly_prepay_series.head_html'),
+              }}
+            />
+            <tbody
+              className={styles.popup_table_body}
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.fly_prepay_series.body_html'),
+              }}
+            />
           </table>
         </ScrollableWrapper>
       </Popup>
@@ -954,44 +572,23 @@ export default function SmsServices() {
         isVisible={activePopup === '1251128'}
         onClose={() => setActivePopup(null)}
       >
-        <div className={styles.popup_title}>Moldtelecom Talk:</div>
+        <div className={styles.popup_title}>
+          {t('sms_services.tables.moldtelecom_talk.title')}
+        </div>
 
         <ScrollableWrapper>
           <table className="popup_table">
-            <thead>
-              <tr>
-                <td>SMS cod</td>
-                <td>Descriere opțiune</td>
-                <td>Tarif, lei</td>
-                <td>Valabilitate</td>
-              </tr>
-            </thead>
-            <tbody className={styles.popup_table_body}>
-              <tr>
-                <td>UT1</td>
-                <td>Activare Moldtelecom Talk</td>
-                <td>0</td>
-                <td>n/a</td>
-              </tr>
-              <tr>
-                <td>STOPUT1</td>
-                <td>Dezactivare Moldtelecom Talk</td>
-                <td>0</td>
-                <td>n/a</td>
-              </tr>
-              <tr>
-                <td>UT</td>
-                <td>Activare Moldtelecom Talk</td>
-                <td>0</td>
-                <td>n/a</td>
-              </tr>
-              <tr>
-                <td>STOPUT</td>
-                <td>Dezactivare Moldtelecom Talk</td>
-                <td>0</td>
-                <td>n/a</td>
-              </tr>
-            </tbody>
+            <thead
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.moldtelecom_talk.head_html'),
+              }}
+            />
+            <tbody
+              className={styles.popup_table_body}
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.moldtelecom_talk.body_html'),
+              }}
+            />
           </table>
         </ScrollableWrapper>
       </Popup>
@@ -1001,62 +598,24 @@ export default function SmsServices() {
         isVisible={activePopup === '1251131'}
         onClose={() => setActivePopup(null)}
       >
-        <div className={styles.popup_title}>Alte posibilităţi:</div>
+        <div className={styles.popup_title}>
+          {t('sms_services.tables.other_possibilities.title')}
+        </div>
 
         <ScrollableWrapper>
           <table className="popup_table">
-            <thead>
-              <tr>
-                <td>
-                  <strong>SMS cod</strong>
-                </td>
-                <td>
-                  <strong>Descriere opțiune</strong>
-                </td>
-                <td>
-                  <strong>Tarif, lei</strong>
-                </td>
-                <td>
-                  <strong>Valabilitate</strong>
-                </td>
-              </tr>
-            </thead>
+            <thead
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.other_possibilities.head_html'),
+              }}
+            />
 
-            <tbody className={styles.popup_table_body}>
-              <tr>
-                <td>R_************</td>
-                <td>Suplinirea contului cu cartela de reîncărcare</td>
-                <td>n/a</td>
-                <td>n/a</td>
-              </tr>
-              <tr>
-                <td>RM_0xxxxxxxx</td>
-                <td>
-                  Expedierea SMS «Reîncarcă-mi contul» la un prieten (numai
-                  numere Moldtelecom), limita 5 sms per/zi
-                </td>
-                <td>n/a</td>
-                <td>n/a</td>
-              </tr>
-              <tr>
-                <td>Callme_0xxxxxxxx</td>
-                <td>
-                  Expedierea SMS «Sună-mă» la un prieten (numai numere
-                  Moldtelecom), limita 5 sms per/zi
-                </td>
-                <td>n/a</td>
-                <td>n/a</td>
-              </tr>
-              <tr>
-                <td>43_1</td>
-                <td>
-                  Activarea expedierii facturii prin email, modificarea va fi
-                  aplicată la următorul billing ciclu.
-                </td>
-                <td>n/a</td>
-                <td>n/a</td>
-              </tr>
-            </tbody>
+            <tbody
+              className={styles.popup_table_body}
+              dangerouslySetInnerHTML={{
+                __html: t('sms_services.tables.other_possibilities.body_html'),
+              }}
+            />
           </table>
         </ScrollableWrapper>
       </Popup>


### PR DESCRIPTION
## Summary
- localize SmsServices popup table content
- add Romanian and Russian table translations

## Testing
- `yarn lint` *(fails: request to registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6870c282a17c83278d13a8312f5a4dd0