### PR TITLE
Add advanced user interaction tracking

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,3 @@
 VITE_RECAPTCHA_SITE_KEY=your_site_key_here
+
+VITE_GA_MEASUREMENT_ID=your_ga_measurement_id_here

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # mtc.md
+
+This project uses Google Analytics to track user interactions. To enable tracking, create a `.env` file based on `.env.template` and provide your Google Analytics measurement ID:
+
+```
+VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+```
+
+Analytics is initialised automatically when the application starts and records clicks on all buttons and links.

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,0 +1,103 @@
+export const initGA = () => {
+  const id = import.meta.env.VITE_GA_MEASUREMENT_ID as string | undefined;
+  if (!id || typeof window === 'undefined') return;
+
+  // Load the gtag script
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${id}`;
+  document.head.appendChild(script);
+
+  // Initialize the dataLayer and gtag function
+  (window as any).dataLayer = (window as any).dataLayer || [];
+  function gtag(...args: any[]) {
+    (window as any).dataLayer.push(args);
+  }
+  (window as any).gtag = gtag;
+
+  gtag('js', new Date());
+  gtag('config', id);
+
+  trackPageView();
+  startPageTracking();
+  startClickTracking();
+  startVisibilityTracking();
+};
+
+export const trackEvent = (
+  action: string,
+  category?: string,
+  label?: string,
+  value?: number
+) => {
+  const id = import.meta.env.VITE_GA_MEASUREMENT_ID as string | undefined;
+  const gtag = (window as any).gtag;
+  if (!id || typeof gtag !== 'function') return;
+
+  gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value,
+    page_path: window.location.pathname,
+  });
+};
+
+export const trackPageView = (path: string = window.location.pathname) => {
+  const id = import.meta.env.VITE_GA_MEASUREMENT_ID as string | undefined;
+  const gtag = (window as any).gtag;
+  if (!id || typeof gtag !== 'function') return;
+
+  gtag('event', 'page_view', {
+    page_path: path,
+    page_location: window.location.href,
+    page_title: document.title,
+  });
+};
+
+export const startPageTracking = () => {
+  const push = history.pushState;
+  history.pushState = function (...args) {
+    push.apply(this, args);
+    trackPageView();
+  } as typeof history.pushState;
+  window.addEventListener('popstate', () => trackPageView());
+};
+
+export const startClickTracking = () => {
+  document.addEventListener('click', event => {
+    const target = event.target as HTMLElement | null;
+    const element = target?.closest('[data-analytics-label], [role="button"], button, a');
+    if (element) {
+      const label =
+        element.getAttribute('data-analytics-label') ||
+        element.id ||
+        (element.textContent || '').trim();
+      const category =
+        element.getAttribute('data-analytics-category') || element.tagName.toLowerCase();
+      const action = element.getAttribute('data-analytics-action') || 'click';
+      trackEvent(action, category, label);
+    }
+  });
+};
+
+export const startVisibilityTracking = () => {
+  const observer = new MutationObserver(mutations => {
+    for (const m of mutations) {
+      if (m.type === 'attributes') {
+        const el = m.target as HTMLElement;
+        if (el.hasAttribute('data-analytics-toggle')) {
+          const isOpen =
+            el.getAttribute('aria-expanded') === 'true' ||
+            el.hasAttribute('open') ||
+            !el.hasAttribute('hidden');
+          const label = el.getAttribute('data-analytics-label') || el.id || el.tagName.toLowerCase();
+          trackEvent(isOpen ? 'open' : 'close', 'toggle', label);
+        }
+      }
+    }
+  });
+  document.querySelectorAll('[data-analytics-toggle]').forEach(el => {
+    observer.observe(el, { attributes: true, attributeFilter: ['open', 'aria-expanded', 'hidden'] });
+  });
+};
+

--- a/src/components/scroll_to_top/ScrollToTop.tsx
+++ b/src/components/scroll_to_top/ScrollToTop.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
+import { trackPageView } from '../../analytics.ts';
 
 interface ScrollToTopProps {
   behavior?: ScrollBehavior; // 'auto' | 'smooth'
@@ -13,6 +14,7 @@ const ScrollToTop: React.FC<ScrollToTopProps> = ({ behavior = 'auto' }) => {
       top: 0,
       behavior,
     });
+    trackPageView(pathname);
   }, [pathname, behavior]);
 
   return null;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
+import { initGA } from './analytics.ts';
+
+initGA();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- expand `analytics.ts` with page view and visibility tracking helpers
- streamline initialization in `main.tsx`
- report page views via `ScrollToTop`

## Testing
- `yarn lint` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_e_6870c7e0278c832795ea231b2f66c47d