### PR TITLE
Improve Google Analytics integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The official Moldtelecom website is built with **React 19**, **TypeScript** and 
 - i18next setup with Romanian, Russian and English translations
 - Progressive Web App configuration via `vite-plugin-pwa`
 - Invisible reCAPTCHA support (`VITE_RECAPTCHA_SITE_KEY`)
-- Google Tag Manager tracking (`VITE_GOOGLE_TRACKING_TAG`)
+- Google Analytics tracking (`VITE_GOOGLE_MEASUREMENT_ID`)
 - Production build and deployment script
 
 ## Requirements
@@ -34,10 +34,10 @@ The official Moldtelecom website is built with **React 19**, **TypeScript** and 
    ```bash
    yarn install
    ```
-2. Copy the example environment file and provide your environment variables(reCAPTCHA key, google tracking key,...):
+2. Copy the example environment file and provide your environment variables (reCAPTCHA key, Google Analytics ID,...):
    ```bash
    cp .env.template .env
-   # edit .env and set VITE_RECAPTCHA_SITE_KEY and VITE_GOOGLE_TRACKING_TAG
+   # edit .env and set VITE_RECAPTCHA_SITE_KEY and VITE_GOOGLE_MEASUREMENT_ID
    ```
 
 ## Development

--- a/index.html
+++ b/index.html
@@ -1,23 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <!-- Google Tag Manager -->
-    <script type="module">
-      const GTM_ID = import.meta.env.VITE_GOOGLE_TAG_MANAGER_ID;
-      if (GTM_ID) {
-        (function(w, d, s, l, i) {
-          w[l] = w[l] || [];
-          w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
-          const f = d.getElementsByTagName(s)[0];
-          const j = d.createElement(s);
-          const dl = l !== 'dataLayer' ? '&l=' + l : '';
-          j.async = true;
-          j.src = `https://www.googletagmanager.com/gtm.js?id=${i}${dl}`;
-          f.parentNode.insertBefore(j, f);
-        })(window, document, 'script', 'dataLayer', GTM_ID);
-      }
-    </script>
-    <!-- End Google Tag Manager -->
 
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
@@ -36,16 +19,6 @@
     <link rel="canonical" href="https://new.moldtelecom.md/" />
   </head>
   <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript
-      ><iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-593FK3G3"
-        height="0"
-        width="0"
-        style="display:none;visibility:hidden"
-      ></iframe
-    ></noscript>
-    <!-- End Google Tag Manager (noscript) -->
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/components/scroll_to_top/ScrollToTop.tsx
+++ b/src/components/scroll_to_top/ScrollToTop.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
+import { trackPageview } from '../../initAnalytics.ts';
 
 interface ScrollToTopProps {
   behavior?: ScrollBehavior; // 'auto' | 'smooth'
@@ -13,6 +14,7 @@ const ScrollToTop: React.FC<ScrollToTopProps> = ({ behavior = 'auto' }) => {
       top: 0,
       behavior,
     });
+    trackPageview(pathname);
   }, [pathname, behavior]);
 
   return null;

--- a/src/initAnalytics.ts
+++ b/src/initAnalytics.ts
@@ -1,0 +1,32 @@
+const GA_ID = import.meta.env.VITE_GOOGLE_MEASUREMENT_ID;
+
+export function initAnalytics() {
+  if (!GA_ID) return;
+
+  // Load gtag script dynamically
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
+  document.head.appendChild(script);
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag(...args: any[]) {
+    window.dataLayer.push(args);
+  }
+  window.gtag = window.gtag || gtag;
+
+  window.gtag('js', new Date());
+  window.gtag('config', GA_ID, { anonymize_ip: true });
+}
+
+export function trackPageview(path: string) {
+  if (window.gtag) {
+    window.gtag('event', 'page_view', { page_path: path });
+  }
+}
+
+export function trackEvent(action: string, label?: string) {
+  if (window.gtag) {
+    window.gtag('event', action, { event_label: label });
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,10 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
+import { initAnalytics, trackPageview } from './initAnalytics.ts';
+
+initAnalytics();
+trackPageview(window.location.pathname);
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/pages/personal/oferte/roaming/Roaming.tsx
+++ b/src/pages/personal/oferte/roaming/Roaming.tsx
@@ -18,6 +18,7 @@ import Slider from 'react-slick';
 import Button from '../../../../components/Button.tsx';
 import Popups from '../../../../components/Popups/Popups.tsx';
 import Popup from '../../../../components/Popup/Popup.tsx';
+import { trackEvent } from '../../../../initAnalytics.ts';
 import Details, {
   DetailsBlock,
 } from '../../../../components/details/Details.tsx';
@@ -51,6 +52,11 @@ export default function Roaming() {
   const faqEntries = t('roaming.faq', { returnObjects: true }) as FaqEntry[];
 
   const [activePopup, setActivePopup] = useState<string | null>(null);
+
+  const openPopup = (id: string) => {
+    setActivePopup(id);
+    trackEvent('roaming_popup', id);
+  };
   const seo = {
     title: t('pages.roaming.title'),
     description: t('pages.roaming.description'),
@@ -106,6 +112,8 @@ export default function Roaming() {
     setCountry(name);
     setFilteredCountries([]);
     setShowSuggestions(false);
+
+    trackEvent('roaming_select_country', name);
 
     fetch(`https://moldtelecom.md/roaming/${encodeURIComponent(name)}`)
       .then(res => res.json())
@@ -338,7 +346,7 @@ export default function Roaming() {
                   {/*  Activează în aplicație*/}
                   {/*</Button>*/}
                   <Button
-                    onClick={() => setActivePopup('f5')}
+                    onClick={() => openPopup('f5')}
                     color="var(--theme_primary_color_blue_4)"
                     bgcolor="var(--theme_primary_color_blue_3)"
                     border="var(--theme_primary_color_blue_3)"
@@ -380,7 +388,7 @@ export default function Roaming() {
                   {/*  Activează în aplicație*/}
                   {/*</Button>*/}
                   <Button
-                    onClick={() => setActivePopup('f6')}
+                    onClick={() => openPopup('f6')}
                     color="var(--theme_primary_color_blue_4)"
                     bgcolor="var(--theme_primary_color_blue_3)"
                     border="var(--theme_primary_color_blue_3)"
@@ -426,7 +434,7 @@ export default function Roaming() {
                     {/*  Activează în aplicație*/}
                     {/*</Button>*/}
                     <Button
-                      onClick={() => setActivePopup('f9')}
+                      onClick={() => openPopup('f9')}
                       color="var(--theme_primary_color_blue_4)"
                       bgcolor="var(--theme_primary_color_blue_3)"
                       border="var(--theme_primary_color_blue_3)"
@@ -499,7 +507,7 @@ export default function Roaming() {
 
           <div className={styles.roaming_tarifs_card_text}>
             {t('roaming.tarifs.text_1')}{' '}
-            <span onClick={() => setActivePopup('1281120')}>
+            <span onClick={() => openPopup('1281120')}>
               {t('roaming.tarifs.text_2')}
             </span>
             .
@@ -546,7 +554,7 @@ export default function Roaming() {
           </div>
           <div className={styles.roaming_activate_right}>
             <div
-              onClick={() => setActivePopup('1281124')}
+              onClick={() => openPopup('1281124')}
               className={`${styles.roaming_activate_right_card} ${styles.roaming_activate_right_card_1}`}
             >
               Vezi pașii de configurare APN

--- a/src/pages/personal/oferte/wifiplus/WifiPlus.tsx
+++ b/src/pages/personal/oferte/wifiplus/WifiPlus.tsx
@@ -14,6 +14,7 @@ import Popup from '../../../../components/Popup/Popup.tsx';
 import Chat from '../../../../components/chat/Chat.tsx';
 import Feedback from '../../../../components/feedback/Feedback.tsx';
 import SEO from '../../../../components/SEO';
+import { trackEvent } from '../../../../initAnalytics.ts';
 
 declare global {
   interface Window {
@@ -60,11 +61,13 @@ export default function WifiPlus() {
 
   const setShowPopupFunction = (packet: string) => {
     setShowPopup(true);
+    trackEvent('wifi_plus_popup', packet);
     console.log(packet);
   };
   setShowPopup;
 
   const trackButton = (label: string) => {
+    trackEvent('wifi_plus_button', label);
     if (window.dataLayer) {
       window.dataLayer.push({ event: 'wifi_plus_button', label });
     }


### PR DESCRIPTION
## Summary
- move analytics setup to `src/initAnalytics.ts`
- send page views in `ScrollToTop`
- initialize analytics in `main.tsx`
- add tracking hooks on Wifi Plus and Roaming pages
- clean GTM snippet from `index.html`
- document new env variable `VITE_GOOGLE_MEASUREMENT_ID`

## Testing
- `yarn lint` *(fails: Request was cancelled)*
- `yarn build` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6878e5f78f7083279ad53ac1c13f4485