### PR TITLE
Fix duplicate GA pageviews

### DIFF
--- a/src/components/scroll_to_top/ScrollToTop.tsx
+++ b/src/components/scroll_to_top/ScrollToTop.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import { trackPageview } from '../../initAnalytics';
 
 interface Props {
   behavior?: ScrollBehavior;
@@ -11,7 +10,6 @@ export default function ScrollToTop({ behavior = 'auto' }: Props) {
 
   useEffect(() => {
     window.scrollTo({ top: 0, behavior });
-    trackPageview(pathname + search, document.title);
   }, [pathname, search, behavior]);
 
   return null;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,10 +2,9 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
-import { initAnalytics, trackPageview } from './initAnalytics.ts';
+import { initAnalytics } from './initAnalytics.ts';
 
 initAnalytics();
-trackPageview(window.location.pathname);
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- remove extra `trackPageview` call from the ScrollToTop component
- stop sending a page view on bootstrap so only AnalyticsListener handles it

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6880983ac6f08327b14cab87a4d1f447