### PR TITLE
feat: add analytics tracking to mobile and double pages

### DIFF
--- a/src/components/details/Details.tsx
+++ b/src/components/details/Details.tsx
@@ -68,9 +68,10 @@ export const DetailsBlock: React.FC<DetailsBlockProps> = ({
  */
 interface DetailsProps {
   children: React.ReactNode;
+  trackPrefix?: string;
 }
 
-const Details: React.FC<DetailsProps> = ({ children }) => {
+const Details: React.FC<DetailsProps> = ({ children, trackPrefix = 'combo' }) => {
   // const { t } = useTranslation();
   const count = React.Children.count(children);
   const [openBlocks, setOpenBlocks] = useState<boolean[]>([]);
@@ -93,7 +94,7 @@ const Details: React.FC<DetailsProps> = ({ children }) => {
       const label = String(child.props.title)
         .replace(/\s+/g, '_')
         .toLowerCase();
-      trackEvent(`combo_detalii+${label}`);
+      trackEvent(`${trackPrefix}_detalii+${label}`);
     }
   };
 

--- a/src/components/faqV2/FaqQAV2.tsx
+++ b/src/components/faqV2/FaqQAV2.tsx
@@ -7,9 +7,15 @@ interface FaqQAProps {
   children: React.ReactNode;
   question: string;
   id_faq: string;
+  trackPrefix?: string;
 }
 
-const FaqQAV2: React.FC<FaqQAProps> = ({ children, question, id_faq }) => {
+const FaqQAV2: React.FC<FaqQAProps> = ({
+  children,
+  question,
+  id_faq,
+  trackPrefix = 'combo',
+}) => {
   const [activeFAQ, setActiveFAQ] = useState(false);
   const [count, setCount] = useState<number>(0);
   const [hasClicked, setHasClicked] = useState<boolean>(false);
@@ -29,7 +35,7 @@ const FaqQAV2: React.FC<FaqQAProps> = ({ children, question, id_faq }) => {
   const toggleFAQ = () => {
     setActiveFAQ(prev => !prev);
 
-    trackEvent(`combo faq${id_faq}`);
+    trackEvent(`${trackPrefix} faq${id_faq}`);
 
     // Only send increment once per page load
     if (!hasClicked) {

--- a/src/pages/personal/oferte/double/Double.tsx
+++ b/src/pages/personal/oferte/double/Double.tsx
@@ -22,6 +22,7 @@ import FaqQAV2 from '../../../../components/faqV2/FaqQAV2.tsx';
 import FaqV2 from '../../../../components/faqV2/FaqV2.tsx';
 import BuyForm from '../../../../components/buy_form/BuyForm.tsx';
 import ShopCard from '../../../../components/shop_card/ShopCard.tsx';
+import { trackEvent } from '../../../../initAnalytics.ts';
 declare global {
   interface Window {
     regiuni: Record<string, Record<string, unknown[]>>;
@@ -849,6 +850,7 @@ export default function Double() {
   );
 
   const setPopup = (id: string, name: string, subname: string) => {
+    trackEvent('double_device_buy', `${name} ${subname}`);
     setActivePopup('1934567');
     setActivePopupConfig(name);
     setActivePopupSubConfig(subname);
@@ -860,6 +862,14 @@ export default function Double() {
     console.log(
       `[${isRegio ? 'regio' : 'non-regio'}] (Internet + TV) Double – ${name} ${subname} (tip - ${activeTVConfig_1}, nr - ${numberTVConfig_1} tv), ${activeMesh_1 ? '+ Wi‑Fi Mesh, ' : ''}${activeSafeweb_1 ? '+ Safe‑Web, ' : ''}${activeMTC_TV_GO_1 ? '+ Moldtelecom TV GO, ' : ''}${activeTelephone_1 ? '+ Telefonie Fixa, ' : ''} (Oferta Back-2-School 2025)`
     );
+  };
+
+  const trackToggle = (
+    event: string,
+    setter: (checked: boolean) => void
+  ) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setter(e.target.checked);
+    trackEvent(event);
   };
 
   const settings_devices = {
@@ -942,19 +952,28 @@ export default function Double() {
       {isRegio ? (
         <div className={styles.config}>
           <div
-            onClick={() => setActiveConfig('1')}
+            onClick={() => {
+              setActiveConfig('1');
+              trackEvent('double_select_type_package_discount');
+            }}
             className={`${styles.config_block} ${styles.config_block_1}  ${styles.config_block_first} ${activeConfig == '1' && styles.config_block_active}`}
           >
             {t('combo_home.package_discount')}
           </div>
           <div
-            onClick={() => setActiveConfig('2')}
+            onClick={() => {
+              setActiveConfig('2');
+              trackEvent('double_select_type_smart_tv_tablet');
+            }}
             className={`${styles.config_block} ${styles.config_block_2}  ${activeConfig == '2' && styles.config_block_active}`}
           >
             {t('combo_home.smart_tv_tablet')}
           </div>
           <div
-            onClick={() => setActiveConfig('3')}
+            onClick={() => {
+              setActiveConfig('3');
+              trackEvent('double_select_type_gaming_set');
+            }}
             className={`${styles.config_block} ${styles.config_block_3}  ${styles.config_block_last} ${activeConfig == '3' && styles.config_block_active}`}
           >
             {t('combo_home.gaming_set')}
@@ -1002,7 +1021,7 @@ export default function Double() {
                   {/*/>*/}
                   <Toggle
                     checked={activeMesh_1}
-                    onChange={e => setActiveMesh_1(e.target.checked)}
+                    onChange={trackToggle('double_mesh_toggle', setActiveMesh_1)}
                   />
                 </div>
                 <span>
@@ -1024,7 +1043,7 @@ export default function Double() {
                   {/*/>*/}
                   <Toggle
                     checked={activeSafeweb_1}
-                    onChange={e => setActiveSafeweb_1(e.target.checked)}
+                    onChange={trackToggle('double_safeweb_toggle', setActiveSafeweb_1)}
                   />
                 </div>
                 <span>
@@ -1164,7 +1183,7 @@ export default function Double() {
                 <div className={styles.abonaments_block_inside_subtitle_toggle}>
                   <Toggle
                     checked={activeMTC_TV_GO_1}
-                    onChange={e => setActiveMTC_TV_GO_1(e.target.checked)}
+                    onChange={trackToggle('double_tvgo_toggle', setActiveMTC_TV_GO_1)}
                   />
                 </div>
                 <span>
@@ -1187,7 +1206,7 @@ export default function Double() {
                 <div className={styles.abonaments_block_inside_subtitle_toggle}>
                   <Toggle
                     checked={activeTelephone_1}
-                    onChange={e => setActiveTelephone_1(e.target.checked)}
+                    onChange={trackToggle('double_telephone_toggle', setActiveTelephone_1)}
                   />
                 </div>
                 <span>
@@ -1304,7 +1323,7 @@ export default function Double() {
                   {/*/>*/}
                   <Toggle
                     checked={activeMesh_2}
-                    onChange={e => setActiveMesh_2(e.target.checked)}
+                    onChange={trackToggle('double_mesh_toggle', setActiveMesh_2)}
                   />
                 </div>
                 <span>
@@ -1326,7 +1345,7 @@ export default function Double() {
                   {/*/>*/}
                   <Toggle
                     checked={activeSafeweb_2}
-                    onChange={e => setActiveSafeweb_2(e.target.checked)}
+                    onChange={trackToggle('double_safeweb_toggle', setActiveSafeweb_2)}
                   />
                 </div>
                 <span>
@@ -1466,7 +1485,7 @@ export default function Double() {
                 <div className={styles.abonaments_block_inside_subtitle_toggle}>
                   <Toggle
                     checked={activeMTC_TV_GO_2}
-                    onChange={e => setActiveMTC_TV_GO_2(e.target.checked)}
+                    onChange={trackToggle('double_tvgo_toggle', setActiveMTC_TV_GO_2)}
                   />
                 </div>
                 <span>
@@ -1489,7 +1508,7 @@ export default function Double() {
                 <div className={styles.abonaments_block_inside_subtitle_toggle}>
                   <Toggle
                     checked={activeTelephone_2}
-                    onChange={e => setActiveTelephone_2(e.target.checked)}
+                    onChange={trackToggle('double_telephone_toggle', setActiveTelephone_2)}
                   />
                 </div>
                 <span>
@@ -1619,7 +1638,7 @@ export default function Double() {
                 {/*/>*/}
                 <Toggle
                   checked={activeMesh_3}
-                  onChange={e => setActiveMesh_3(e.target.checked)}
+                  onChange={trackToggle('double_mesh_toggle', setActiveMesh_3)}
                 />
               </div>
               <span>
@@ -1639,7 +1658,7 @@ export default function Double() {
                 {/*/>*/}
                 <Toggle
                   checked={activeSafeweb_3}
-                  onChange={e => setActiveSafeweb_3(e.target.checked)}
+                  onChange={trackToggle('double_safeweb_toggle', setActiveSafeweb_3)}
                 />
               </div>
               <span>
@@ -1776,7 +1795,7 @@ export default function Double() {
               <div className={styles.abonaments_block_inside_subtitle_toggle}>
                 <Toggle
                   checked={activeMTC_TV_GO_3}
-                  onChange={e => setActiveMTC_TV_GO_3(e.target.checked)}
+                  onChange={trackToggle('double_tvgo_toggle', setActiveMTC_TV_GO_3)}
                 />
               </div>
               <span>
@@ -1797,7 +1816,7 @@ export default function Double() {
               <div className={styles.abonaments_block_inside_subtitle_toggle}>
                 <Toggle
                   checked={activeTelephone_3}
-                  onChange={e => setActiveTelephone_3(e.target.checked)}
+                  onChange={trackToggle('double_telephone_toggle', setActiveTelephone_3)}
                 />
               </div>
               <span>
@@ -1933,7 +1952,7 @@ export default function Double() {
                 {/*/>*/}
                 <Toggle
                   checked={activeMesh_4}
-                  onChange={e => setActiveMesh_4(e.target.checked)}
+                  onChange={trackToggle('double_mesh_toggle', setActiveMesh_4)}
                 />
               </div>
               <span>
@@ -1953,7 +1972,7 @@ export default function Double() {
                 {/*/>*/}
                 <Toggle
                   checked={activeSafeweb_4}
-                  onChange={e => setActiveSafeweb_4(e.target.checked)}
+                  onChange={trackToggle('double_safeweb_toggle', setActiveSafeweb_4)}
                 />
               </div>
               <span>
@@ -2090,7 +2109,7 @@ export default function Double() {
               <div className={styles.abonaments_block_inside_subtitle_toggle}>
                 <Toggle
                   checked={activeMTC_TV_GO_4}
-                  onChange={e => setActiveMTC_TV_GO_4(e.target.checked)}
+                  onChange={trackToggle('double_tvgo_toggle', setActiveMTC_TV_GO_4)}
                 />
               </div>
               <span>
@@ -2111,7 +2130,7 @@ export default function Double() {
               <div className={styles.abonaments_block_inside_subtitle_toggle}>
                 <Toggle
                   checked={activeTelephone_4}
-                  onChange={e => setActiveTelephone_4(e.target.checked)}
+                  onChange={trackToggle('double_telephone_toggle', setActiveTelephone_4)}
                 />
               </div>
               <span>
@@ -2244,7 +2263,7 @@ export default function Double() {
                 {/*/>*/}
                 <Toggle
                   checked={activeMesh_5}
-                  onChange={e => setActiveMesh_5(e.target.checked)}
+                  onChange={trackToggle('double_mesh_toggle', setActiveMesh_5)}
                 />
               </div>
               <span>
@@ -2264,7 +2283,7 @@ export default function Double() {
                 {/*/>*/}
                 <Toggle
                   checked={activeSafeweb_5}
-                  onChange={e => setActiveSafeweb_5(e.target.checked)}
+                  onChange={trackToggle('double_safeweb_toggle', setActiveSafeweb_5)}
                 />
               </div>
               <span>
@@ -2401,7 +2420,7 @@ export default function Double() {
               <div className={styles.abonaments_block_inside_subtitle_toggle}>
                 <Toggle
                   checked={activeMTC_TV_GO_5}
-                  onChange={e => setActiveMTC_TV_GO_5(e.target.checked)}
+                  onChange={trackToggle('double_tvgo_toggle', setActiveMTC_TV_GO_5)}
                 />
               </div>
               <span>
@@ -2422,7 +2441,7 @@ export default function Double() {
               <div className={styles.abonaments_block_inside_subtitle_toggle}>
                 <Toggle
                   checked={activeTelephone_5}
-                  onChange={e => setActiveTelephone_5(e.target.checked)}
+                  onChange={trackToggle('double_telephone_toggle', setActiveTelephone_5)}
                 />
               </div>
               <span>
@@ -2522,7 +2541,7 @@ export default function Double() {
         </div>
       </Slider>
 
-      <Details>
+      <Details trackPrefix="double">
         <DetailsBlock title={t('combo_home.conditii_1.title')}>
           <ul>
             <li>{t('combo_home.conditii_1.item_1')}</li>
@@ -2843,60 +2862,70 @@ export default function Double() {
 
       <FaqV2 max_faq={5}>
         <FaqQAV2
+          trackPrefix="double"
           id_faq="112089314"
           question={t('combo_home.faq.install_duration_question')}
         >
           {t('combo_home.faq.install_duration_answer')}
         </FaqQAV2>
         <FaqQAV2
+          trackPrefix="double"
           id_faq="112089315"
           question={t('combo_home.faq.availability_check_question')}
         >
           {t('combo_home.faq.availability_check_answer')}
         </FaqQAV2>
         <FaqQAV2
+          trackPrefix="double"
           id_faq="112089316"
           question={t('combo_home.faq.activate_new_offer_question')}
         >
           {t('combo_home.faq.activate_new_offer_answer')}
         </FaqQAV2>
         <FaqQAV2
+          trackPrefix="double"
           id_faq="112089317"
           question={t('combo_home.faq.bill_payment_deadline_question')}
         >
           {t('combo_home.faq.bill_payment_deadline_answer')}
         </FaqQAV2>
         <FaqQAV2
+          trackPrefix="double"
           id_faq="112089318"
           question={t('combo_home.faq.late_payment_consequences_question')}
         >
           {t('combo_home.faq.late_payment_consequences_answer')}
         </FaqQAV2>
         <FaqQAV2
+          trackPrefix="double"
           id_faq="112089319"
           question={t('combo_home.faq.manage_subscription_remotely_question')}
         >
           {t('combo_home.faq.manage_subscription_remotely_answer')}
         </FaqQAV2>
         <FaqQAV2
+          trackPrefix="double"
           id_faq="112089320"
           question={t('combo_home.faq.pause_services_question')}
         >
           {t('combo_home.faq.pause_services_answer')}
         </FaqQAV2>
         <FaqQAV2
+          trackPrefix="double"
           id_faq="112089321"
           question={t('combo_home.faq.change_package_question')}
         >
           {t('combo_home.faq.change_package_answer')}
         </FaqQAV2>
         <FaqQAV2
+          trackPrefix="double"
           id_faq="112089322"
           question={t('combo_home.faq.move_address_question')}
         >
           {t('combo_home.faq.move_address_answer')}
         </FaqQAV2>
         <FaqQAV2
+          trackPrefix="double"
           id_faq="112089323"
           question={t('combo_home.faq.transfer_subscription_question')}
         >

--- a/src/pages/personal/oferte/mobile/Mobile.tsx
+++ b/src/pages/personal/oferte/mobile/Mobile.tsx
@@ -24,6 +24,7 @@ import FaqV2 from '../../../../components/faqV2/FaqV2.tsx';
 import FaqQAV2 from '../../../../components/faqV2/FaqQAV2.tsx';
 import ShopCard from '../../../../components/shop_card/ShopCard.tsx';
 import ScrollableWrapper from '../../../../components/Popup/ScrollableWrapper.tsx';
+import { trackEvent } from '../../../../initAnalytics.ts';
 
 export default function Mobile() {
   const { t } = useTranslation();
@@ -53,11 +54,12 @@ export default function Mobile() {
 
   const handleClick = (type: 'sim' | 'esim') => {
     setSelected(type);
-    // console.log(type);
+    trackEvent('tm_sim_select', type);
   };
   const [activePopupSubConfig, setActivePopupSubConfig] = useState<string>('');
   const [activeBuyConfig, setActiveBuyConfig] = useState<string>('');
   const setPopup = (name: string, subname: string) => {
+    trackEvent('tm_device_buy', `${name} ${subname}`);
     setActivePopup('1934567');
     setActivePopupConfig(name);
     setActivePopupSubConfig(subname);
@@ -188,6 +190,7 @@ export default function Mobile() {
       <div className={styles.select_type}>
         <div
           className={`${styles.select_type_card} ${styles.select_type_card_active}`}
+          onClick={() => trackEvent('tm_select_type_abonament')}
         >
           <div className={styles.select_type_card_top}>
             <Icon
@@ -201,9 +204,10 @@ export default function Mobile() {
         </div>
         <div
           className={styles.select_type_card}
-          onClick={() =>
-            goToPage(`https://www.moldtelecom.md/${t('lang')}/personal/Portare`)
-          }
+          onClick={() => {
+            trackEvent('tm_select_type_portare');
+            goToPage(`https://www.moldtelecom.md/${t('lang')}/personal/Portare`);
+          }}
         >
           <div className={styles.select_type_card_top}>
             <Icon
@@ -217,11 +221,12 @@ export default function Mobile() {
         </div>
         <div
           className={styles.select_type_card}
-          onClick={() =>
+          onClick={() => {
+            trackEvent('tm_select_type_prepay');
             goToPage(
               `https://www.moldtelecom.md/${t('lang')}/personal/prepay-cartela`
-            )
-          }
+            );
+          }}
         >
           <div className={styles.select_type_card_top}>
             <Icon
@@ -241,6 +246,7 @@ export default function Mobile() {
 
       <div className={`${styles.btns_select}`}>
         <Button
+          id="tm_not_client"
           color={'var(--theme_primary_color_blue_4)'}
           bgcolor={
             activeConfig == '1'
@@ -257,6 +263,7 @@ export default function Mobile() {
           {t('tm.btn_not_client')}
         </Button>
         <Button
+          id="tm_client"
           color={'var(--theme_primary_color_blue_4)'}
           bgcolor={
             activeConfig == '2'
@@ -378,6 +385,7 @@ export default function Mobile() {
                 </div>
               </div>
               <Button
+                id="tm_start95_order"
                 // onClick={() => setShowPopupFunction('aaa')}
                 onClick={() =>
                   handleConfigClick(
@@ -488,6 +496,7 @@ export default function Mobile() {
                 </div>
               </div>
               <Button
+                id="tm_star120_order"
                 // onClick={() => setShowPopupFunction('aaa')}
                 onClick={() =>
                   handleConfigClick(
@@ -609,6 +618,7 @@ export default function Mobile() {
                 </div>
               </div>
               <Button
+                id="tm_star150_order"
                 // onClick={() => setShowPopupFunction('aaa')}
                 onClick={() =>
                   handleConfigClick(
@@ -759,6 +769,7 @@ export default function Mobile() {
                 </div>
               </div>
               <Button
+                id="tm_liberty190_order"
                 // onClick={() => setShowPopupFunction('aaa')}
                 onClick={() =>
                   handleConfigClick(
@@ -908,6 +919,7 @@ export default function Mobile() {
                 </div>
               </div>
               <Button
+                id="tm_liberty250plus_order"
                 // onClick={() => setShowPopupFunction('aaa')}
                 onClick={() =>
                   handleConfigClick(
@@ -933,7 +945,7 @@ export default function Mobile() {
           </div>
         </div>
       </Slider>
-      <Details>
+      <Details trackPrefix="tm">
         <DetailsBlock title={t('tm.details.promo.title')}>
           <ul>
             {promoItems.map((text, i) => (
@@ -1135,19 +1147,35 @@ export default function Mobile() {
       <MyApp style_type={'blue_white'} className={styles.myapp} />
 
       <FaqV2 max_faq={6}>
-        <FaqQAV2 id_faq="112489310" question={t('tm.faq.112489310.question')}>
+        <FaqQAV2
+          trackPrefix="tm"
+          id_faq="112489310"
+          question={t('tm.faq.112489310.question')}
+        >
           {t('tm.faq.112489310.answer')}
         </FaqQAV2>
 
-        <FaqQAV2 id_faq="112489311" question={t('tm.faq.112489311.question')}>
+        <FaqQAV2
+          trackPrefix="tm"
+          id_faq="112489311"
+          question={t('tm.faq.112489311.question')}
+        >
           {t('tm.faq.112489311.answer')}
         </FaqQAV2>
 
-        <FaqQAV2 id_faq="112489312" question={t('tm.faq.112489312.question')}>
+        <FaqQAV2
+          trackPrefix="tm"
+          id_faq="112489312"
+          question={t('tm.faq.112489312.question')}
+        >
           {t('tm.faq.112489312.answer')}
         </FaqQAV2>
 
-        <FaqQAV2 id_faq="112489313" question={t('tm.faq.112489313.question')}>
+        <FaqQAV2
+          trackPrefix="tm"
+          id_faq="112489313"
+          question={t('tm.faq.112489313.question')}
+        >
           <span
             dangerouslySetInnerHTML={{
               __html: t('tm.faq.112489313.answer'),
@@ -1155,19 +1183,35 @@ export default function Mobile() {
           />
         </FaqQAV2>
 
-        <FaqQAV2 id_faq="112489314" question={t('tm.faq.112489314.question')}>
+        <FaqQAV2
+          trackPrefix="tm"
+          id_faq="112489314"
+          question={t('tm.faq.112489314.question')}
+        >
           {t('tm.faq.112489314.answer')}
         </FaqQAV2>
 
-        <FaqQAV2 id_faq="112489315" question={t('tm.faq.112489315.question')}>
+        <FaqQAV2
+          trackPrefix="tm"
+          id_faq="112489315"
+          question={t('tm.faq.112489315.question')}
+        >
           {t('tm.faq.112489315.answer')}
         </FaqQAV2>
 
-        <FaqQAV2 id_faq="112489316" question={t('tm.faq.112489316.question')}>
+        <FaqQAV2
+          trackPrefix="tm"
+          id_faq="112489316"
+          question={t('tm.faq.112489316.question')}
+        >
           {t('tm.faq.112489316.answer')}
         </FaqQAV2>
 
-        <FaqQAV2 id_faq="112489317" question={t('tm.faq.112489317.question')}>
+        <FaqQAV2
+          trackPrefix="tm"
+          id_faq="112489317"
+          question={t('tm.faq.112489317.question')}
+        >
           {t('tm.faq.112489317.answer')}
         </FaqQAV2>
 
@@ -1175,7 +1219,11 @@ export default function Mobile() {
         {/*  {t('tm.faq.112489318.answer')}*/}
         {/*</FaqQAV2>*/}
 
-        <FaqQAV2 id_faq="112489319" question={t('tm.faq.112489319.question')}>
+        <FaqQAV2
+          trackPrefix="tm"
+          id_faq="112489319"
+          question={t('tm.faq.112489319.question')}
+        >
           {t('tm.faq.112489319.answer')}
         </FaqQAV2>
       </FaqV2>
@@ -1266,7 +1314,10 @@ export default function Mobile() {
                 <div className={styles.popup_option}>
                   <Toggle
                     checked={testGratis}
-                    onChange={() => setTestGratis(prev => !prev)}
+                    onChange={() => {
+                      setTestGratis(prev => !prev);
+                      trackEvent('tm_test_gratis_toggle');
+                    }}
                   />
                   <span>
                     {' '}


### PR DESCRIPTION
## Summary
- add trackPrefix prop to FAQ and Details components for customizable analytics events
- instrument mobile and double offers pages with Google tracking for selection cards, order buttons, FAQ entries, optional service toggles, and pop-up controls

## Testing
- `yarn lint` *(fails: Unexpected any in unrelated files)*
- `npx eslint src/pages/personal/oferte/mobile/Mobile.tsx src/components/details/Details.tsx src/components/faqV2/FaqQAV2.tsx src/pages/personal/oferte/double/Double.tsx`
- `npx tsc --noEmit -p tsconfig.app.json`


------
https://chatgpt.com/codex/tasks/task_e_6894422ea0888327918e8c65126ac83b