### PR TITLE
Add SEO metadata for promo, Internet Only, and Gaming pages

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -481,6 +481,21 @@
       "description": "Use the same phone number on multiple devices and stay reachable on all your gadgets.",
       "keywords": "one number, multi device, smartwatch, tablet, phone, number sharing, mobile, calls, sms, Moldtelecom"
     },
+    "only_net": {
+      "title": "Internet Only",
+      "description": "Choose high-speed fixed internet plans with exclusive online discounts.",
+      "keywords": "internet only, fixed internet, plans, offers, moldtelecom"
+    },
+    "gaming": {
+      "title": "Gaming",
+      "description": "Consoles, subscriptions and offers tailored for gamers.",
+      "keywords": "gaming, consoles, fast internet, offers, moldtelecom"
+    },
+    "back_to_school": {
+      "title": "Back to School",
+      "description": "Promotions for the start of the school year on devices and subscriptions from Moldtelecom.",
+      "keywords": "back to school, promotions, discounts, devices, moldtelecom"
+    },
     "home": {
       "title": "Moldtelecom",
       "description": "Official Moldtelecom website with information about services, offers and the latest news.",

--- a/src/lang/ro.json
+++ b/src/lang/ro.json
@@ -1606,6 +1606,21 @@
       "title": "SMS Service 100",
       "description": "Activează rapid opțiuni și servicii Moldtelecom trimițând coduri SMS la numărul 100.",
       "keywords": "sms service, opțiuni, pachete, internet, minute, roaming, moldtelecom, 100"
+    },
+    "only_net": {
+      "title": "Doar Internet",
+      "description": "Alege abonamente de Internet fix de mare viteză cu reduceri exclusive pentru online.",
+      "keywords": "doar internet, internet fix, abonamente, oferte, moldtelecom"
+    },
+    "gaming": {
+      "title": "Gaming",
+      "description": "Console, abonamente și oferte pentru pasionații de gaming.",
+      "keywords": "gaming, console, internet rapid, oferte, moldtelecom"
+    },
+    "back_to_school": {
+      "title": "Back to School",
+      "description": "Promoții pentru începutul anului școlar la dispozitive și abonamente Moldtelecom.",
+      "keywords": "back to school, promoții, reduceri, dispozitive, moldtelecom"
     }
   },
   "navbar_business": {

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -1637,6 +1637,21 @@
       "title": "SMS Service 100",
       "description": "Быстро активируйте опции и услуги Moldtelecom, отправляя SMS‑коды на номер 100.",
       "keywords": "sms service, опции, пакеты, интернет, минуты, роуминг, moldtelecom, 100"
+    },
+    "only_net": {
+      "title": "Только Интернет",
+      "description": "Выбирайте тарифы фиксированного интернета на высокой скорости со специальными онлайн‑скидками.",
+      "keywords": "только интернет, фиксированный интернет, тарифы, акции, moldtelecom"
+    },
+    "gaming": {
+      "title": "Гейминг",
+      "description": "Приставки, подписки и предложения для любителей игр.",
+      "keywords": "гейминг, приставки, быстрый интернет, акции, moldtelecom"
+    },
+    "back_to_school": {
+      "title": "Back to School",
+      "description": "Акции к началу учебного года на устройства и абонементы Moldtelecom.",
+      "keywords": "back to school, акции, скидки, устройства, moldtelecom"
     }
   },
   "home": {

--- a/src/pages/eshop/promo_b2s/Promo1536965.tsx
+++ b/src/pages/eshop/promo_b2s/Promo1536965.tsx
@@ -7,6 +7,7 @@ import Footer from '../../../components/footer/Footer.tsx';
 import styles from './Promo1536965.module.css';
 import Hero from '../../../components/hero/Hero.tsx';
 import { useTranslation } from 'react-i18next';
+import SEO from '../../../components/SEO';
 import ShopCard from '../../../components/shop_card/ShopCard.tsx';
 import Icon from '../../../components/Icon.tsx';
 
@@ -160,6 +161,11 @@ export default function Promo1536965() {
   }, [targetMs]);
 
   const { t } = useTranslation();
+  const seo = {
+    title: t('pages.back_to_school.title'),
+    description: t('pages.back_to_school.description'),
+    keywords: t('pages.back_to_school.keywords'),
+  };
   const breadcrumbItems = [
     {
       label: 'Magazin Online',
@@ -410,6 +416,7 @@ export default function Promo1536965() {
 
   return (
     <>
+      <SEO {...seo} />
       <Navbar />
       <Chat />
       <Feedback />

--- a/src/pages/personal/oferte/gaming/Gaming.tsx
+++ b/src/pages/personal/oferte/gaming/Gaming.tsx
@@ -9,6 +9,7 @@ import MyApp from '../../../../components/app/MyApp.tsx';
 import Footer from '../../../../components/footer/Footer.tsx';
 import FaqQAV2 from '../../../../components/faqV2/FaqQAV2.tsx';
 import FaqV2 from '../../../../components/faqV2/FaqV2.tsx';
+import SEO from '../../../../components/SEO';
 
 import Button from '../../../../components/Button.tsx';
 import Slider from 'react-slick';
@@ -148,6 +149,11 @@ const OptionsIcon: React.FC = () => (
 
 export default function Gaming() {
   const { t } = useTranslation();
+  const seo = {
+    title: t('pages.gaming.title'),
+    description: t('pages.gaming.description'),
+    keywords: t('pages.gaming.keywords'),
+  };
 
   const breadcrumbItems = [{ label: 'Promo', url: ' ' }, { label: 'Gaming' }];
 
@@ -433,6 +439,7 @@ export default function Gaming() {
 
   return (
     <>
+      <SEO {...seo} />
       <Navbar />
       <Chat />
       <Feedback />


### PR DESCRIPTION
## Summary
- add `<SEO>` metadata to Back to School promo page
- add missing SEO to gaming page
- provide multilingual SEO strings for Back to School, Internet Only, and Gaming

## Testing
- `yarn lint` *(fails: Unexpected any & other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689c23afdb2483279d091258feb84894