### PR TITLE
feat: add SEO translations

### DIFF
--- a/src/components/app/AppRedirect.tsx
+++ b/src/components/app/AppRedirect.tsx
@@ -1,6 +1,14 @@
 import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import SEO from '../SEO';
 
-export default function AppRedirect(): null {
+export default function AppRedirect(): JSX.Element {
+  const { t } = useTranslation();
+  const seo = {
+    title: t('pages.mymtc.title'),
+    description: t('pages.mymtc.description'),
+    keywords: t('pages.mymtc.keywords'),
+  };
   useEffect(() => {
     const ua = navigator.userAgent || navigator.vendor || '';
     let url: string;
@@ -33,5 +41,5 @@ export default function AppRedirect(): null {
     }
   }, []);
 
-  return null;
+  return <SEO {...seo} />;
 }

--- a/src/lang/ro.json
+++ b/src/lang/ro.json
@@ -1626,6 +1626,46 @@
       "title": "Back to School 2025",
       "description": "Promoții pentru începutul anului școlar la dispozitive și abonamente Moldtelecom.",
       "keywords": "back to school, promoții, reduceri, dispozitive, moldtelecom"
+    },
+    "notfound": {
+      "title": "Pagina nu a fost găsită",
+      "description": "Pagina solicitată nu a fost găsită pe site-ul Moldtelecom.",
+      "keywords": "404, pagină nu există, moldtelecom, not found"
+    },
+    "securitatea_digitala": {
+      "title": "Securitate digitală",
+      "description": "Resurse și sfaturi pentru protecția datelor și navigare sigură online.",
+      "keywords": "securitate digitală, protecția datelor, internet sigur, moldtelecom"
+    },
+    "contacts": {
+      "title": "Contacte Moldtelecom",
+      "description": "Date de contact și modalități de suport pentru clienți Moldtelecom.",
+      "keywords": "contacte, suport clienți, moldtelecom, telefon, email"
+    },
+    "icons": {
+      "title": "Colecție de iconițe",
+      "description": "Demonstrație tehnică a setului de iconițe utilizate în proiect.",
+      "keywords": "iconițe, pictograme, demo, tehnic"
+    },
+    "mymtc": {
+      "title": "Descarcă aplicația MyMoldtelecom",
+      "description": "Redirecționare către aplicația MyMoldtelecom pentru iOS, Android sau web.",
+      "keywords": "mymoldtelecom, aplicație, descărcare, moldtelecom, ios, android"
+    },
+    "five_gbps": {
+      "title": "Internet 5.5 Gbps",
+      "description": "Oferta Moldtelecom cu viteză de 5.5 Gbps și acoperire totală în casă.",
+      "keywords": "5.5 gbps, internet rapid, wifi 6, xgs-pon, moldtelecom"
+    },
+    "form_test": {
+      "title": "Formular test",
+      "description": "Pagină de test pentru formulare și funcționalități interne.",
+      "keywords": "test, formular, intern"
+    },
+    "politica_roaming": {
+      "title": "Politica de utilizare rezonabilă Roaming Europa",
+      "description": "Reguli privind utilizarea rezonabilă a serviciului Roaming Europa oferit de Moldtelecom.",
+      "keywords": "politica roaming, utilizare rezonabilă, roaming europa, moldtelecom"
     }
   },
   "pormo_b2s_2025": {

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -1657,6 +1657,46 @@
       "title": "Back to School 2025",
       "description": "Акции к началу учебного года на устройства и абонементы Moldtelecom.",
       "keywords": "back to school, акции, скидки, устройства, moldtelecom"
+    },
+    "notfound": {
+      "title": "Страница не найдена",
+      "description": "Запрошенная страница не найдена на сайте Moldtelecom.",
+      "keywords": "404, страница не найдена, moldtelecom, not found"
+    },
+    "securitatea_digitala": {
+      "title": "Цифровая безопасность",
+      "description": "Ресурсы и советы по защите данных и безопасному использованию интернета.",
+      "keywords": "цифровая безопасность, защита данных, безопасный интернет, moldtelecom"
+    },
+    "contacts": {
+      "title": "Контакты Moldtelecom",
+      "description": "Контактные данные и способы поддержки клиентов Moldtelecom.",
+      "keywords": "контакты, поддержка клиентов, moldtelecom, телефон, email"
+    },
+    "icons": {
+      "title": "Демонстрация иконок",
+      "description": "Техническая демонстрация набора иконок, используемых в проекте.",
+      "keywords": "иконки, демонстрация, технический"
+    },
+    "mymtc": {
+      "title": "Скачать приложение MyMoldtelecom",
+      "description": "Переадресация в приложение MyMoldtelecom для iOS, Android или web.",
+      "keywords": "mymoldtelecom, приложение, скачать, moldtelecom, ios, android"
+    },
+    "five_gbps": {
+      "title": "Интернет 5.5 Gbps",
+      "description": "Предложение Moldtelecom со скоростью 5.5 Gbps и полным покрытием дома.",
+      "keywords": "5.5 gbps, быстрый интернет, wifi 6, xgs-pon, moldtelecom"
+    },
+    "form_test": {
+      "title": "Тестовая страница формы",
+      "description": "Тестовая страница для форм и внутренних функций.",
+      "keywords": "тест, форма, внутренний"
+    },
+    "politica_roaming": {
+      "title": "Политика разумного использования Roaming Europa",
+      "description": "Правила разумного использования услуги Roaming Europa от Moldtelecom.",
+      "keywords": "политика роуминг, разумное использование, roaming europa, moldtelecom"
     }
   },
   "pormo_b2s_2025": {

--- a/src/pages/costume/PoliticaRoaming/PoliticaRoaming.tsx
+++ b/src/pages/costume/PoliticaRoaming/PoliticaRoaming.tsx
@@ -1,23 +1,30 @@
 import Breadcrumb from '../../../components/Breadcrumb/Breadcrumb.tsx';
-// import { useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import Chat from '../../../components/chat/Chat.tsx';
 import Feedback from '../../../components/feedback/Feedback.tsx';
 import Navbar from '../../../components/navbar/Navbar.tsx';
 import styles from './PoliticaRoaming.module.css';
 import Footer from '../../../components/footer/Footer.tsx';
+import SEO from '../../../components/SEO';
 
 // import CostumeFunctions from '../../../components/functions/CostumeFunctions.tsx';
 
 export default function PoliticaRoaming() {
-  // const { t } = useTranslation();
+  const { t } = useTranslation();
   const breadcrumbItems = [
     // { label: 'politica-de-utilizare-rezonabila-a-serviciului-roaming-europa' },
     { label: 'Politica de utilizare rezonabilă', url: ' ' },
     { label: 'Roaming-Europa' },
   ];
+  const seo = {
+    title: t('pages.politica_roaming.title'),
+    description: t('pages.politica_roaming.description'),
+    keywords: t('pages.politica_roaming.keywords'),
+  };
 
   return (
     <>
+      <SEO {...seo} />
       <Navbar />
       <Chat />
       <Feedback />

--- a/src/pages/not_found/NotFound.tsx
+++ b/src/pages/not_found/NotFound.tsx
@@ -6,13 +6,20 @@ import Breadcrumb from '../../components/Breadcrumb/Breadcrumb.tsx';
 import Footer from '../../components/footer/Footer.tsx';
 import styles from './NotFound.module.css';
 import Button from '../../components/Button.tsx';
+import SEO from '../../components/SEO';
 
 export default function NotFound() {
   const { t } = useTranslation();
   const breadcrumbItems = [{ label: t('notfound.breadcrumb.title') }];
+  const seo = {
+    title: t('pages.notfound.title'),
+    description: t('pages.notfound.description'),
+    keywords: t('pages.notfound.keywords'),
+  };
 
   return (
     <>
+      <SEO {...seo} />
       <Navbar />
       <Chat />
       <Feedback />

--- a/src/pages/personal/SecuritrateDigitala/SecuritateDigitala.tsx
+++ b/src/pages/personal/SecuritrateDigitala/SecuritateDigitala.tsx
@@ -7,13 +7,20 @@ import Footer from '../../../components/footer/Footer.tsx';
 import { useTranslation } from 'react-i18next';
 import Chat from '../../../components/chat/Chat.tsx';
 import Feedback from '../../../components/feedback/Feedback.tsx';
+import SEO from '../../../components/SEO';
 
 export default function SecuritateDigitala() {
   const { t } = useTranslation();
   const breadcrumbItems = [{ label: 'Securitrate Digitala' }];
+  const seo = {
+    title: t('pages.securitatea_digitala.title'),
+    description: t('pages.securitatea_digitala.description'),
+    keywords: t('pages.securitatea_digitala.keywords'),
+  };
 
   return (
     <>
+      <SEO {...seo} />
       <Navbar />
       <Chat />
       <Feedback />

--- a/src/pages/personal/contacts/Contacts.tsx
+++ b/src/pages/personal/contacts/Contacts.tsx
@@ -5,6 +5,7 @@ import Feedback from '../../../components/feedback/Feedback.tsx';
 import Breadcrumb from '../../../components/Breadcrumb/Breadcrumb.tsx';
 import Footer from '../../../components/footer/Footer.tsx';
 // import styles from './Promo1536965.module.css';
+import SEO from '../../../components/SEO';
 
 export default function Contacts() {
   const { t } = useTranslation();
@@ -12,9 +13,15 @@ export default function Contacts() {
     { label: t('contacts.breadcrumb.help'), url: ' ' },
     { label: t('contacts.breadcrumb.title') },
   ];
+  const seo = {
+    title: t('pages.contacts.title'),
+    description: t('pages.contacts.description'),
+    keywords: t('pages.contacts.keywords'),
+  };
 
   return (
     <>
+      <SEO {...seo} />
       <Navbar />
       <Chat />
       <Feedback />

--- a/src/pages/personal/oferte/5gbps/FiveGbps.tsx
+++ b/src/pages/personal/oferte/5gbps/FiveGbps.tsx
@@ -19,9 +19,15 @@ import Popup from '../../../../components/Popup/Popup.tsx';
 import BuyForm from '../../../../components/buy_form/BuyForm.tsx';
 import { useState } from 'react';
 import { trackEvent } from '../../../../initAnalytics.ts';
+import SEO from '../../../../components/SEO';
 
 export default function FiveGbps() {
   const { t } = useTranslation();
+  const seo = {
+    title: t('pages.five_gbps.title'),
+    description: t('pages.five_gbps.description'),
+    keywords: t('pages.five_gbps.keywords'),
+  };
 
   const [activePopup, setActivePopup] = useState<string | null>(null);
   const [popupType, setPopupType] = useState(false);
@@ -80,6 +86,7 @@ export default function FiveGbps() {
 
   return (
     <>
+      <SEO {...seo} />
       <Navbar />
       <Chat />
       <Feedback />

--- a/src/pages/technical/IconShowcase.tsx
+++ b/src/pages/technical/IconShowcase.tsx
@@ -1,12 +1,21 @@
 import Icon, { icons } from '../../components/Icon.tsx';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import SEO from '../../components/SEO';
 
 export default function IconShowcase() {
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const [searchQuery, setSearchQuery] = useState('');
+  const seo = {
+    title: t('pages.icons.title'),
+    description: t('pages.icons.description'),
+    keywords: t('pages.icons.keywords'),
+  };
   return (
     <>
+      <SEO {...seo} />
       <h3>Icons Showcase</h3>
 
       <input

--- a/src/pages/test/Test.tsx
+++ b/src/pages/test/Test.tsx
@@ -1,7 +1,15 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import SEO from '../../components/SEO';
 
 export default function FormTestPage() {
+  const { t } = useTranslation();
   const [phone, setPhone] = useState('');
+  const seo = {
+    title: t('pages.form_test.title'),
+    description: t('pages.form_test.description'),
+    keywords: t('pages.form_test.keywords'),
+  };
 
   const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -12,11 +20,13 @@ export default function FormTestPage() {
   };
 
   return (
-    <form
-      action="https://www.moldtelecom.md/comanda_marketing"
-      data-type="thankyou-page-form"
-      method="post"
-    >
+    <>
+      <SEO {...seo} />
+      <form
+        action="https://www.moldtelecom.md/comanda_marketing"
+        data-type="thankyou-page-form"
+        method="post"
+      >
       <input
         type="tel"
         inputMode="numeric"
@@ -61,5 +71,6 @@ export default function FormTestPage() {
         value="3zqS1thx5283Dl6XJ786we75Pw1RNr9PhBzHiq8z"
       />
     </form>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add SEO metadata for missing pages
- provide Romanian and Russian translations for new SEO entries

## Testing
- `yarn lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68a4478ac5108327a177a9e973436120